### PR TITLE
fix pypi publish.yaml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI or TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     # Not intended for forks.
     if: github.repository == 'optuna/optuna-integration'


### PR DESCRIPTION
## Motivation
CI fails because the ubuntu version which is used in pypi-publish.yml is old.

## Description of the changes
- Fix pypi-publish.yml.
