### PR TITLE
Fix optuna integration sentences

### DIFF
--- a/optuna_integration/allennlp/__init__.py
+++ b/optuna_integration/allennlp/__init__.py
@@ -1,6 +1,6 @@
-from optuna.integration.allennlp._dump_best_config import dump_best_config
-from optuna.integration.allennlp._executor import AllenNLPExecutor
-from optuna.integration.allennlp._pruner import AllenNLPPruningCallback
+from optuna_integration.allennlp._dump_best_config import dump_best_config
+from optuna_integration.allennlp._executor import AllenNLPExecutor
+from optuna_integration.allennlp._pruner import AllenNLPPruningCallback
 
 
 __all__ = ["dump_best_config", "AllenNLPExecutor", "AllenNLPPruningCallback"]

--- a/optuna_integration/allennlp/_dump_best_config.py
+++ b/optuna_integration/allennlp/_dump_best_config.py
@@ -2,6 +2,7 @@ import json
 
 import optuna
 from optuna._imports import try_import
+
 from optuna_integration.allennlp._environment import _environment_variables
 
 

--- a/optuna_integration/allennlp/_dump_best_config.py
+++ b/optuna_integration/allennlp/_dump_best_config.py
@@ -2,7 +2,7 @@ import json
 
 import optuna
 from optuna._imports import try_import
-from optuna.integration.allennlp._environment import _environment_variables
+from optuna_integration.allennlp._environment import _environment_variables
 
 
 with try_import() as _imports:
@@ -15,7 +15,7 @@ def dump_best_config(input_config_file: str, output_config_file: str, study: opt
     Args:
         input_config_file:
             Input Jsonnet config file used with
-            :class:`~optuna.integration.AllenNLPExecutor`.
+            :class:`~optuna_integration.AllenNLPExecutor`.
         output_config_file:
             Output JSON config file.
         study:

--- a/optuna_integration/allennlp/_executor.py
+++ b/optuna_integration/allennlp/_executor.py
@@ -11,9 +11,9 @@ import optuna
 from optuna import TrialPruned
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
-from optuna.integration.allennlp._environment import _environment_variables
-from optuna.integration.allennlp._variables import _VariableManager
-from optuna.integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
+from optuna_integration.allennlp._environment import _environment_variables
+from optuna_integration.allennlp._variables import _VariableManager
+from optuna_integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
 
 
 with try_import() as _imports:
@@ -85,7 +85,7 @@ class AllenNLPExecutor:
         allennlp/classifier.jsonnet>`_.
 
     .. note::
-        In :class:`~optuna.integration.AllenNLPExecutor`,
+        In :class:`~optuna_integration.AllenNLPExecutor`,
         you can pass parameters to AllenNLP by either defining a search space using
         Optuna suggest methods or setting environment variables just like AllenNLP CLI.
         If a value is set in both a search space in Optuna and the environment variables,
@@ -106,7 +106,7 @@ class AllenNLPExecutor:
             An evaluation metric. `GradientDescrentTrainer.train() <https://docs.allennlp.org/
             main/api/training/gradient_descent_trainer/#train>`_ of AllenNLP
             returns a dictionary containing metrics after training.
-            :class:`~optuna.integration.AllenNLPExecutor` accesses the dictionary
+            :class:`~optuna_integration.AllenNLPExecutor` accesses the dictionary
             by the key ``metrics`` you specify and use it as a objective value.
         force:
             If :obj:`True`, an executor overwrites the output directory if it exists.
@@ -144,7 +144,7 @@ class AllenNLPExecutor:
         if isinstance(include_package, str):
             include_package = [include_package]
 
-        self._include_package = include_package + ["optuna.integration.allennlp"]
+        self._include_package = include_package + ["optuna_integration.allennlp"]
 
         storage = trial.study._storage
 

--- a/optuna_integration/allennlp/_executor.py
+++ b/optuna_integration/allennlp/_executor.py
@@ -11,6 +11,7 @@ import optuna
 from optuna import TrialPruned
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
+
 from optuna_integration.allennlp._environment import _environment_variables
 from optuna_integration.allennlp._variables import _VariableManager
 from optuna_integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG

--- a/optuna_integration/allennlp/_pruner.py
+++ b/optuna_integration/allennlp/_pruner.py
@@ -10,8 +10,8 @@ from optuna import Trial
 from optuna import TrialPruned
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
-from optuna.integration.allennlp._variables import _VariableManager
-from optuna.integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
+from optuna_integration.allennlp._variables import _VariableManager
+from optuna_integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
 from packaging import version
 
 
@@ -84,14 +84,14 @@ class AllenNLPPruningCallback(TrainerCallback):
     `AllenNLP Guide <https://guide.allennlp.org/hyperparameter-optimization>`_.
 
     .. note::
-        When :class:`~optuna.integration.AllenNLPPruningCallback` is instantiated in Python script,
+        When :class:`~optuna_integration.AllenNLPPruningCallback` is instantiated in Python script,
         trial and monitor are mandatory.
 
-        On the other hand, when :class:`~optuna.integration.AllenNLPPruningCallback` is used with
-        :class:`~optuna.integration.AllenNLPExecutor`, ``trial`` and ``monitor``
-        would be :obj:`None`. :class:`~optuna.integration.AllenNLPExecutor` sets
+        On the other hand, when :class:`~optuna_integration.AllenNLPPruningCallback` is used with
+        :class:`~optuna_integration.AllenNLPExecutor`, ``trial`` and ``monitor``
+        would be :obj:`None`. :class:`~optuna_integration.AllenNLPExecutor` sets
         environment variables for a study name, trial id, monitor, and storage.
-        Then :class:`~optuna.integration.AllenNLPPruningCallback`
+        Then :class:`~optuna_integration.AllenNLPPruningCallback`
         loads them to restore ``trial`` and ``monitor``.
 
     .. note::

--- a/optuna_integration/allennlp/_pruner.py
+++ b/optuna_integration/allennlp/_pruner.py
@@ -10,9 +10,10 @@ from optuna import Trial
 from optuna import TrialPruned
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
+from packaging import version
+
 from optuna_integration.allennlp._variables import _VariableManager
 from optuna_integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
-from packaging import version
 
 
 with try_import() as _imports:

--- a/optuna_integration/allennlp/_variables.py
+++ b/optuna_integration/allennlp/_variables.py
@@ -35,7 +35,7 @@ class _VariableManager:
         "study_name": "{}_STUDY_NAME",
         "trial_id": "{}_TRIAL_ID",
     }
-    NAME_OF_PATH = "optuna.integration.allennlp._variables._VariableManager.NAME_OF_KEY"
+    NAME_OF_PATH = "optuna_integration.allennlp._variables._VariableManager.NAME_OF_KEY"
 
     def __init__(self, target_pid: int) -> None:
         self.target_pid = target_pid
@@ -53,7 +53,7 @@ class _VariableManager:
     def set_value(self, name: str, value: Any) -> None:
         """Set values to environment variables.
 
-        `set_value` is only invoked in `optuna.integration.allennlp.AllenNLPExecutor`.
+        `set_value` is only invoked in `optuna_integration.allennlp.AllenNLPExecutor`.
 
         """
         key = self._get_key(name).format(self.target_pid)
@@ -62,7 +62,7 @@ class _VariableManager:
     def get_value(self, name: str) -> Any:
         """Fetch parameters from environment variables.
 
-        `get_value` is only called in `optuna.integration.allennlp.AllenNLPPruningCallback`.
+        `get_value` is only called in `optuna_integration.allennlp.AllenNLPPruningCallback`.
 
         """
         key = self._get_key(name).format(self.target_pid)

--- a/optuna_integration/chainermn.py
+++ b/optuna_integration/chainermn.py
@@ -25,7 +25,7 @@ with try_import() as _imports:
     from chainermn.communicators.communicator_base import CommunicatorBase  # NOQA
 
 
-_suggest_deprecated_msg = "Use :func:`~optuna.integration.ChainerMNTrial.suggest_float` instead."
+_suggest_deprecated_msg = "Use :func:`~optuna_integration.ChainerMNTrial.suggest_float` instead."
 
 
 class _ChainerMNObjectiveFunc:
@@ -58,7 +58,7 @@ class ChainerMNStudy:
     """A wrapper of :class:`~optuna.study.Study` to incorporate Optuna with ChainerMN.
 
     .. seealso::
-        :class:`~optuna.integration.chainermn.ChainerMNStudy` provides the same interface as
+        :class:`~optuna_integration.chainermn.ChainerMNStudy` provides the same interface as
         :class:`~optuna.study.Study`. Please refer to :class:`optuna.study.Study` for further
         details.
 
@@ -145,7 +145,7 @@ class ChainerMNTrial(BaseTrial):
     """A wrapper of :class:`~optuna.trial.Trial` to incorporate Optuna with ChainerMN.
 
     .. seealso::
-        :class:`~optuna.integration.chainermn.ChainerMNTrial` provides the same interface as
+        :class:`~optuna_integration.chainermn.ChainerMNTrial` provides the same interface as
         :class:`~optuna.trial.Trial`. Please refer to :class:`optuna.trial.Trial` for further
         details.
 

--- a/optuna_integration/keras.py
+++ b/optuna_integration/keras.py
@@ -20,7 +20,7 @@ _keras_pruning_callback_deprecated_msg = (
     "Test before upgrading. "
     "REF: https://github.com/keras-team/keras/releases/tag/2.4.0. "
     "There is an alternative callback function that can be used instead: "
-    ":class:`~optuna.integration.TFKerasPruningCallback`"
+    ":class:`~optuna_integration.TFKerasPruningCallback`"
 )
 
 

--- a/tests/allennlp_tests/test_allennlp.py
+++ b/tests/allennlp_tests/test_allennlp.py
@@ -8,11 +8,12 @@ from unittest import mock
 
 import optuna
 from optuna._imports import try_import
+from optuna.testing.pruners import DeterministicPruner
+import pytest
+
 from optuna_integration.allennlp import AllenNLPPruningCallback
 from optuna_integration.allennlp._pruner import _create_pruner
 from optuna_integration.allennlp._variables import _VariableManager
-from optuna.testing.pruners import DeterministicPruner
-import pytest
 
 
 with try_import():

--- a/tests/allennlp_tests/test_allennlp.py
+++ b/tests/allennlp_tests/test_allennlp.py
@@ -8,9 +8,9 @@ from unittest import mock
 
 import optuna
 from optuna._imports import try_import
-from optuna.integration.allennlp import AllenNLPPruningCallback
-from optuna.integration.allennlp._pruner import _create_pruner
-from optuna.integration.allennlp._variables import _VariableManager
+from optuna_integration.allennlp import AllenNLPPruningCallback
+from optuna_integration.allennlp._pruner import _create_pruner
+from optuna_integration.allennlp._variables import _VariableManager
 from optuna.testing.pruners import DeterministicPruner
 import pytest
 

--- a/tests/test_chainer.py
+++ b/tests/test_chainer.py
@@ -73,7 +73,7 @@ def test_chainer_pruning_extension() -> None:
         updater = chainer.training.StandardUpdater(train_iter, optimizer)
         trainer = chainer.training.Trainer(updater, (1, "epoch"))
         trainer.extend(
-            optuna.integration.chainer.ChainerPruningExtension(trial, "main/loss", (1, "epoch"))
+            optuna_integration.chainer.ChainerPruningExtension(trial, "main/loss", (1, "epoch"))
         )
 
         trainer.run(show_loop_exception_msg=False)

--- a/tests/test_chainer.py
+++ b/tests/test_chainer.py
@@ -73,7 +73,7 @@ def test_chainer_pruning_extension() -> None:
         updater = chainer.training.StandardUpdater(train_iter, optimizer)
         trainer = chainer.training.Trainer(updater, (1, "epoch"))
         trainer.extend(
-            optuna_integration.chainer.ChainerPruningExtension(trial, "main/loss", (1, "epoch"))
+            ChainerPruningExtension(trial, "main/loss", (1, "epoch"))
         )
 
         trainer.run(show_loop_exception_msg=False)


### PR DESCRIPTION
## Motivation
Currently, `allennlp` integration module uses its module code from `optuna.integration`.
But, after merging https://github.com/optuna/optuna/pull/4579 this code no longer works.

## Description of the changes
- Fix `optuna.integration` sentences
