### PR TITLE
Copy `_imports.py` from optuna

### DIFF
--- a/optuna_integration/_imports.py
+++ b/optuna_integration/_imports.py
@@ -1,0 +1,125 @@
+import importlib
+import types
+from types import TracebackType
+from typing import Any
+from typing import Optional
+from typing import Tuple
+from typing import Type
+
+
+class _DeferredImportExceptionContextManager:
+    """Context manager to defer exceptions from imports.
+
+    Catches :exc:`ImportError` and :exc:`SyntaxError`.
+    If any exception is caught, this class raises an :exc:`ImportError` when being checked.
+
+    """
+
+    def __init__(self) -> None:
+        self._deferred: Optional[Tuple[Exception, str]] = None
+
+    def __enter__(self) -> "_DeferredImportExceptionContextManager":
+        """Enter the context manager.
+
+        Returns:
+            Itself.
+
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[Exception]],
+        exc_value: Optional[Exception],
+        traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
+        """Exit the context manager.
+
+        Args:
+            exc_type:
+                Raised exception type. :obj:`None` if nothing is raised.
+            exc_value:
+                Raised exception object. :obj:`None` if nothing is raised.
+            traceback:
+                Associated traceback. :obj:`None` if nothing is raised.
+
+        Returns:
+            :obj:`None` if nothing is deferred, otherwise :obj:`True`.
+            :obj:`True` will suppress any exceptions avoiding them from propagating.
+
+        """
+        if isinstance(exc_value, (ImportError, SyntaxError)):
+            if isinstance(exc_value, ImportError):
+                message = (
+                    "Tried to import '{}' but failed. Please make sure that the package is "
+                    "installed correctly to use this feature. Actual error: {}."
+                ).format(exc_value.name, exc_value)
+            elif isinstance(exc_value, SyntaxError):
+                message = (
+                    "Tried to import a package but failed due to a syntax error in {}. Please "
+                    "make sure that the Python version is correct to use this feature. Actual "
+                    "error: {}."
+                ).format(exc_value.filename, exc_value)
+            else:
+                assert False
+
+            self._deferred = (exc_value, message)
+            return True
+        return None
+
+    def is_successful(self) -> bool:
+        """Return whether the context manager has caught any exceptions.
+
+        Returns:
+            :obj:`True` if no exceptions are caught, :obj:`False` otherwise.
+
+        """
+        return self._deferred is None
+
+    def check(self) -> None:
+        """Check whether the context manager has caught any exceptions.
+
+        Raises:
+            :exc:`ImportError`:
+                If any exception was caught from the caught exception.
+
+        """
+        if self._deferred is not None:
+            exc_value, message = self._deferred
+            raise ImportError(message) from exc_value
+
+
+def try_import() -> _DeferredImportExceptionContextManager:
+    """Create a context manager that can wrap imports of optional packages to defer exceptions.
+
+    Returns:
+        Deferred import context manager.
+
+    """
+    return _DeferredImportExceptionContextManager()
+
+
+class _LazyImport(types.ModuleType):
+    """Module wrapper for lazy import.
+
+    This class wraps the specified modules and lazily imports them only when accessed.
+    Otherwise, `import optuna` is slowed down by importing all submodules and
+    dependencies even if not required.
+    Within this project's usage, importlib override this module's attribute on the first
+    access and the imported submodule is directly accessed from the second access.
+
+    Args:
+        name: Name of module to apply lazy import.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self._name = name
+
+    def _load(self) -> types.ModuleType:
+        module = importlib.import_module(self._name)
+        self.__dict__.update(module.__dict__)
+        return module
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._load(), item)

--- a/optuna_integration/allennlp/__init__.py
+++ b/optuna_integration/allennlp/__init__.py
@@ -1,6 +1,6 @@
-from optuna.integration.allennlp._dump_best_config import dump_best_config
-from optuna.integration.allennlp._executor import AllenNLPExecutor
-from optuna.integration.allennlp._pruner import AllenNLPPruningCallback
+from optuna_integration.allennlp._dump_best_config import dump_best_config
+from optuna_integration.allennlp._executor import AllenNLPExecutor
+from optuna_integration.allennlp._pruner import AllenNLPPruningCallback
 
 
 __all__ = ["dump_best_config", "AllenNLPExecutor", "AllenNLPPruningCallback"]

--- a/optuna_integration/allennlp/_dump_best_config.py
+++ b/optuna_integration/allennlp/_dump_best_config.py
@@ -1,8 +1,9 @@
 import json
 
 import optuna
-from optuna._imports import try_import
 from optuna.integration.allennlp._environment import _environment_variables
+
+from optuna_integration._imports import try_import
 
 
 with try_import() as _imports:

--- a/optuna_integration/allennlp/_executor.py
+++ b/optuna_integration/allennlp/_executor.py
@@ -8,10 +8,11 @@ import warnings
 import optuna
 from optuna import TrialPruned
 from optuna._experimental import experimental_class
-from optuna._imports import try_import
 from optuna.integration.allennlp._environment import _environment_variables
 from optuna.integration.allennlp._variables import _VariableManager
 from optuna.integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
+
+from optuna_integration._imports import try_import
 
 
 with try_import() as _imports:

--- a/optuna_integration/allennlp/_pruner.py
+++ b/optuna_integration/allennlp/_pruner.py
@@ -9,10 +9,11 @@ from optuna import pruners
 from optuna import Trial
 from optuna import TrialPruned
 from optuna._experimental import experimental_class
-from optuna._imports import try_import
 from optuna.integration.allennlp._variables import _VariableManager
 from optuna.integration.allennlp._variables import OPTUNA_ALLENNLP_DISTRIBUTED_FLAG
 from packaging import version
+
+from optuna_integration._imports import try_import
 
 
 with try_import() as _imports:

--- a/optuna_integration/chainer.py
+++ b/optuna_integration/chainer.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import optuna
 
+from optuna_integration._imports import try_import
 
-with optuna._imports.try_import() as _imports:
+
+with try_import() as _imports:
     import chainer
     from chainer.training.extension import Extension
     from chainer.training.triggers import IntervalTrigger  # type: ignore[attr-defined]

--- a/optuna_integration/chainermn.py
+++ b/optuna_integration/chainermn.py
@@ -9,7 +9,6 @@ import warnings
 
 from optuna import TrialPruned
 from optuna._deprecated import deprecated_func
-from optuna._imports import try_import
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalChoiceType
 from optuna.storages import InMemoryStorage
@@ -17,6 +16,8 @@ from optuna.storages import RDBStorage
 from optuna.study import Study
 from optuna.trial import BaseTrial
 from optuna.trial import Trial
+
+from optuna_integration._imports import try_import
 
 
 with try_import() as _imports:

--- a/optuna_integration/keras.py
+++ b/optuna_integration/keras.py
@@ -5,8 +5,10 @@ import warnings
 import optuna
 from optuna._deprecated import deprecated_class
 
+from optuna_integration._imports import try_import
 
-with optuna._imports.try_import() as _imports:
+
+with try_import() as _imports:
     from keras.callbacks import Callback
 
 if not _imports.is_successful():

--- a/tests/allennlp_tests/test_allennlp.py
+++ b/tests/allennlp_tests/test_allennlp.py
@@ -6,15 +6,16 @@ import tempfile
 from unittest import mock
 
 import optuna
-from optuna._imports import try_import
 from optuna.integration.allennlp import AllenNLPPruningCallback
 from optuna.integration.allennlp._pruner import _create_pruner
 from optuna.integration.allennlp._variables import _VariableManager
 from optuna.testing.pruners import DeterministicPruner
 import pytest
 
+from optuna_integration._imports import try_import
 
-with try_import():
+
+with try_import() as _imports:
     import _jsonnet
     import psutil
     import torch.optim

--- a/tests/test_chainer.py
+++ b/tests/test_chainer.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 
 import numpy as np
 import optuna
-from optuna._imports import try_import
 from optuna.testing.pruners import DeterministicPruner
 import pytest
 
+from optuna_integration._imports import try_import
 from optuna_integration.chainer import ChainerPruningExtension
 
 

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 import optuna
-from optuna._imports import try_import
 from optuna.testing.pruners import DeterministicPruner
 import pytest
 
+from optuna_integration._imports import try_import
 from optuna_integration.keras import KerasPruningCallback
 
 
-with try_import():
+with try_import() as _imports:
     from keras import Sequential
     from keras.layers import Dense
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The `optuna._imports` module is useful to import some 3rd party modules lazily. In `optuna-integration`, we use it, but it is a private module in Optuna. So, I suggested to copy it in `optuna-integration` and use it.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Copy Optuna's `imports.py` to `optuna-integration`
- Use the copied `_imports` module in codes