### PR TITLE
Load `sphinxcontrib.jquery` explicitly

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,9 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
+    # TODO(toshihikoyanase) remove jQuery extension after
+    # https://github.com/readthedocs/sphinx_rtd_theme/issues/1452 is resolved.
+    "sphinxcontrib.jquery",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Motivation

Apply the patch in https://github.com/optuna/optuna/pull/4615 to `optuna-integration` docs.
This hotfix will resolve the following issues
- Search results are not shown
- Menu pop-up does not work as expected

![image](https://user-images.githubusercontent.com/3255979/234772122-bdb2103b-bcf7-4100-92eb-e2a91343193c.png)


![image](https://user-images.githubusercontent.com/3255979/234771464-8f1795e6-549d-4a4e-a0d9-53a4043026f1.png)

## Description of the changes

- Load `sphinxcontrib.jquery` explicitly.
- Note that this change will be removed after https://github.com/readthedocs/sphinx_rtd_theme/issues/1452 is resolved.
