### PR TITLE
Move `tf.keras` integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,8 @@ jobs:
         if [ ${{ matrix.python-version }} == 3.11 ]; then
           pytest tests\
             --ignore tests/allennlp_tests \
-            --ignore tests/test_keras.py
+            --ignore tests/test_keras.py \
+            --ignore tests/test_tfkeras.py
         else
           pytest tests
         fi

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Optuna-Integration API reference is [here](https://optuna-integration.readthedoc
 * [Chainer](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainer)  ([example](https://github.com/optuna/optuna-examples/tree/main/chainer/chainer_integration.py))
 * [ChainerMN](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainermn)  ([example](https://github.com/optuna/optuna-examples/tree/main/chainer/chainermn_simple.py))
 * [Keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#keras)  ([example](https://github.com/optuna/optuna-examples/tree/main/keras))
+* [tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)  ([example](https://github.com/optuna/optuna-examples/tree/main/tfkerastfkeras_integration.py))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Optuna-Integration API reference is [here](https://optuna-integration.readthedoc
 * [Chainer](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainer)  ([example](https://github.com/optuna/optuna-examples/tree/main/chainer/chainer_integration.py))
 * [ChainerMN](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainermn)  ([example](https://github.com/optuna/optuna-examples/tree/main/chainer/chainermn_simple.py))
 * [Keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#keras)  ([example](https://github.com/optuna/optuna-examples/tree/main/keras))
-* [tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)  ([example](https://github.com/optuna/optuna-examples/tree/main/tfkerastfkeras_integration.py))
+* [tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)  ([example](https://github.com/optuna/optuna-examples/blob/main/tfkeras/tfkeras_integration.py))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Optuna-Integration API reference is [here](https://optuna-integration.readthedoc
 * [Chainer](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainer)  ([example](https://github.com/optuna/optuna-examples/tree/main/chainer/chainer_integration.py))
 * [ChainerMN](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainermn)  ([example](https://github.com/optuna/optuna-examples/tree/main/chainer/chainermn_simple.py))
 * [Keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#keras)  ([example](https://github.com/optuna/optuna-examples/tree/main/keras))
-* [tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)  ([example](https://github.com/optuna/optuna-examples/blob/main/tfkeras/tfkeras_integration.py))
+* [tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)  ([example](https://github.com/optuna/optuna-examples/tree/main/tfkeras/tfkeras_integration.py))
 
 ## Installation
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -34,7 +34,7 @@ Chainer
    :toctree: generated/
    :nosignatures:
 
-   optuna.integration.ChainerPruningExtension 
+   optuna.integration.ChainerPruningExtension
    optuna.integration.ChainerMNStudy
 
 Keras
@@ -45,3 +45,12 @@ Keras
    :nosignatures:
 
    optuna.integration.KerasPruningCallback
+
+TensorFlow
+----------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   optuna.integration.TFKerasPruningCallback

--- a/optuna_integration/tfkeras.py
+++ b/optuna_integration/tfkeras.py
@@ -1,0 +1,60 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+import warnings
+
+import optuna
+
+
+with optuna._imports.try_import() as _imports:
+    from tensorflow.keras.callbacks import Callback
+
+if not _imports.is_successful():
+    Callback = object  # NOQA
+
+
+class TFKerasPruningCallback(Callback):
+    """tf.keras callback to prune unpromising trials.
+
+    This callback is intend to be compatible for TensorFlow v1 and v2,
+    but only tested with TensorFlow v2.
+
+    See `the example <https://github.com/optuna/optuna-examples/blob/main/
+    tfkeras/tfkeras_integration.py>`__
+    if you want to add a pruning callback which observes the validation accuracy.
+
+    Args:
+        trial:
+            A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the
+            objective function.
+        monitor:
+            An evaluation metric for pruning, e.g., ``val_loss`` or ``val_acc``.
+    """
+
+    def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:
+        super().__init__()
+
+        _imports.check()
+
+        self._trial = trial
+        self._monitor = monitor
+
+    def on_epoch_end(self, epoch: int, logs: Optional[Dict[str, Any]] = None) -> None:
+        logs = logs or {}
+        current_score = logs.get(self._monitor)
+
+        if current_score is None:
+            message = (
+                "The metric '{}' is not in the evaluation logs for pruning. "
+                "Please make sure you set the correct metric name.".format(self._monitor)
+            )
+            warnings.warn(message)
+            return
+
+        # Report current score and epoch to Optuna's trial.
+        self._trial.report(float(current_score), step=epoch)
+
+        # Prune trial if needed
+        if self._trial.should_prune():
+            message = "Trial was pruned at epoch {}.".format(epoch)
+            raise optuna.TrialPruned(message)

--- a/optuna_integration/tfkeras.py
+++ b/optuna_integration/tfkeras.py
@@ -5,8 +5,10 @@ import warnings
 
 import optuna
 
+from optuna_integration._imports import try_import
 
-with optuna._imports.try_import() as _imports:
+
+with try_import() as _imports:
     from tensorflow.keras.callbacks import Callback
 
 if not _imports.is_successful():

--- a/tests/test_tfkeras.py
+++ b/tests/test_tfkeras.py
@@ -1,11 +1,11 @@
 import numpy as np
+import optuna
+from optuna._imports import try_import
+from optuna.testing.pruners import DeterministicPruner
 from packaging import version
 import pytest
 
-import optuna
-from optuna._imports import try_import
-from optuna.integration import TFKerasPruningCallback
-from optuna.testing.pruners import DeterministicPruner
+from optuna_integration.tfkeras import TFKerasPruningCallback
 
 
 with try_import():

--- a/tests/test_tfkeras.py
+++ b/tests/test_tfkeras.py
@@ -1,0 +1,67 @@
+import numpy as np
+from packaging import version
+import pytest
+
+import optuna
+from optuna._imports import try_import
+from optuna.integration import TFKerasPruningCallback
+from optuna.testing.pruners import DeterministicPruner
+
+
+with try_import():
+    import tensorflow as tf
+
+pytestmark = pytest.mark.integration
+
+
+def test_tfkeras_pruning_callback() -> None:
+    def objective(trial: optuna.trial.Trial) -> float:
+        model = tf.keras.Sequential()
+        model.add(tf.keras.layers.Dense(1, activation="sigmoid", input_dim=20))
+        model.compile(optimizer="rmsprop", loss="binary_crossentropy", metrics=["accuracy"])
+
+        # TODO(Yanase): Unify the metric with 'accuracy' after stopping TensorFlow 1.x support.
+        callback_metric_name = "accuracy"
+        if version.parse(tf.__version__) < version.parse("2.0.0"):
+            callback_metric_name = "acc"
+
+        model.fit(
+            np.zeros((16, 20), np.float32),
+            np.zeros((16,), np.int32),
+            batch_size=1,
+            epochs=1,
+            callbacks=[TFKerasPruningCallback(trial, callback_metric_name)],
+            verbose=0,
+        )
+
+        return 1.0
+
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.trial.TrialState.PRUNED
+
+    study = optuna.create_study(pruner=DeterministicPruner(False))
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].state == optuna.trial.TrialState.COMPLETE
+    assert study.trials[0].value == 1.0
+
+
+def test_tfkeras_pruning_callback_observation_isnan() -> None:
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    trial = study.ask()
+    callback = TFKerasPruningCallback(trial, "loss")
+
+    with pytest.raises(optuna.TrialPruned):
+        callback.on_epoch_end(0, {"loss": 1.0})
+
+    with pytest.raises(optuna.TrialPruned):
+        callback.on_epoch_end(0, {"loss": float("nan")})
+
+
+def test_tfkeras_pruning_callback_monitor_is_invalid() -> None:
+    study = optuna.create_study(pruner=DeterministicPruner(True))
+    trial = study.ask()
+    callback = TFKerasPruningCallback(trial, "InvalidMonitor")
+
+    with pytest.warns(UserWarning):
+        callback.on_epoch_end(0, {"loss": 1.0})

--- a/tests/test_tfkeras.py
+++ b/tests/test_tfkeras.py
@@ -1,10 +1,10 @@
 import numpy as np
 import optuna
-from optuna._imports import try_import
 from optuna.testing.pruners import DeterministicPruner
 from packaging import version
 import pytest
 
+from optuna_integration._imports import try_import
 from optuna_integration.tfkeras import TFKerasPruningCallback
 
 


### PR DESCRIPTION
## Motivation

This PR is a part of https://github.com/optuna/optuna/issues/4484. It isolates the `tf.keras` integration.

## Description of the changes

Move `optuna/integration/tfkeras.py` to `optuna_integration/tfkeras.py`