### PR TITLE
Fix the CI with AllenNLP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,11 @@ jobs:
         pip install --progress-bar off .[test]
         pip install --progress-bar off .[all]
 
+        # TODO(not522): Remove the version constraint when splitting this workflow.
+        # This constraint is necessary to use the old Pydantic.
+        # See https://github.com/pydantic/pydantic/issues/5821.
+        pip install "typing_extensions<4.6.0"
+
         # Install optuna from specified repository, otherwise from optuna/optuna.
         $( test ${{ inputs.repository_name }} && test ${{ inputs.branch_name }} ) \
           && pip install git+https://github.com/${{ inputs.repository_name }}@${{ inputs.branch_name }} \


### PR DESCRIPTION
## Motivation
With the release of typing-extension v4.6.0, Pydantic now produces an error.
It is fixed in the latest Pydantic (https://github.com/pydantic/pydantic/issues/5821), but we cannot use it because AllenNLP specifies the old spaCy and it specifies the old Pydantic.

## Description of the changes
- Add a version constraint.
