### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout


### PR DESCRIPTION
## Motivation
The release of tensorboardX v2.6.2 breaks catalyst's CI on Python 3.7. (https://github.com/optuna/optuna-integration/actions/runs/5708836457)
Python 3.7 support for integration module has been dropped. This PR reflects it to the CI on this repository.

ref: https://github.com/optuna/optuna/issues/4586, https://github.com/optuna/optuna/pull/4784

## Description of the changes
Remove Python 3.7 from Tests CI.