### PR TITLE
Remove non oldest and latest Python versions from tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,29 +23,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  define-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Define workflow matrix
-      id: set-matrix
-      run: |
-        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
-          echo "Schedule tests (run all the versions)"
-          echo "matrix={\"python-version\":[\"3.8\", \"3.9\", \"3.10\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        else
-          echo "PR push tests (run only the oldest and the latest versions)"
-          echo "matrix={\"python-version\":[\"3.8\", \"3.11\"]}" >> $GITHUB_OUTPUT
-        fi
-
   tests:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna-integration') || (github.event_name != 'schedule')
-    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        should-skip:
+          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+        exclude:
+          - should-skip: true
+            python-version: "3.9"
+          - should-skip: true
+            python-version: "3.10"
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,12 +30,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        should-skip:
-          - ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch') }}
+        test-trigger-type:
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'Scheduled' || '' }}
         exclude:
-          - should-skip: true
+          - test-trigger-type: ""
             python-version: "3.9"
-          - should-skip: true
+          - test-trigger-type: ""
             python-version: "3.10"
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,13 +23,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Define workflow matrix
+      id: set-matrix
+      run: |
+        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+          echo "Schedule tests (run all the versions)"
+          echo "matrix={\"python-version\":[\"3.8\", \"3.9\", \"3.10\", \"3.11\"]}" >> $GITHUB_OUTPUT
+        else
+          echo "PR push tests (run only the oldest and the latest versions)"
+          echo "matrix={\"python-version\":[\"3.8\", \"3.11\"]}" >> $GITHUB_OUTPUT
+        fi
+
   tests:
     if: (github.event_name == 'schedule' && github.repository == 'optuna/optuna-integration') || (github.event_name != 'schedule')
+    needs: define-matrix
     runs-on: ubuntu-latest
 
     strategy:
-      matrix:
-        python-version: ['3.8', '3.11']
+      matrix: ${{fromJson(needs.define-matrix.outputs.matrix)}}
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.11']
 
     steps:
     - name: Checkout


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR aims to reduce the runtime of tests at each PR push.
The changes made here are based on [PR#5067](https://github.com/optuna/optuna/pull/5067) in Optuna.

## Description of the changes
<!-- Describe the changes in this PR. -->

The changes are as follows:
1. add a dynamic workflow matrix for each test, and
2. remove non-oldest and non-latest Python versions from each test.