### PR TITLE
Fix coverage source path

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 concurrency = multiprocessing,thread
-source = optuna
+source = optuna_integration
 
 [report]
 include_namespace_packages = true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,7 +70,7 @@ jobs:
         COVERAGE_PROCESS_START: .coveragerc  # https://coverage.readthedocs.io/en/6.4.1/subprocess.html
         COVERAGE_COVERAGE: yes  # https://github.com/nedbat/coveragepy/blob/65bf33fc03209ffb01bbbc0d900017614645ee7a/coverage/control.py#L255-L261
       run: |
-        coverage run --source=optuna -m pytest tests \
+        coverage run --source=optuna_integration -m pytest tests \
           --ignore tests/test_mxnet.py
         coverage combine
         coverage xml


### PR DESCRIPTION
## Motivation
The test coverage is not correctly calculated because of the wrong source path.

## Description of the changes
- Fix the source path to `optuna_integration` from `optuna`.