### PR TITLE
Fix the doc for TensorFlow

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -152,7 +152,7 @@ TensorFlow
    :toctree: generated/
    :nosignatures:
 
-   optuna.integration.TFKerasPruningCallback
+   optuna_integration.TFKerasPruningCallback
 
 XGBoost
 -------


### PR DESCRIPTION
## Motivation & Description of the changes
- Generate the Tensorflow doc from `optuna_integration` rather than `optuna.integration`.