### PR TITLE
Add skopt dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ all = [
   "pandas",
   "shap",
   "scikit-learn>=0.24.2",
+  "scikit-optimize",
   "scipy>=1.9.2; python_version>='3.8'",
   "skorch",
   "tensorboard",


### PR DESCRIPTION
## Motivation & Description of the changes
- Add `scikit-optimize` to `pyroject.toml` because it is a dependency for the skopt integration.
- This is a follow-up task for https://github.com/optuna/optuna-integration/pull/74.