### PR TITLE
Fix import path

### DIFF
--- a/optuna_integration/xgboost.py
+++ b/optuna_integration/xgboost.py
@@ -2,12 +2,12 @@ from typing import Any
 
 import optuna
 
-import optuna_integration
+from optuna_integration._imports import try_import
 
 
 use_callback_cls = True
 
-with optuna_integration._imports.try_import() as _imports:
+with try_import() as _imports:
     import xgboost as xgb
 
     xgboost_version = xgb.__version__.split(".")


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
Fix CI failure in `optuna/example`. See https://github.com/optuna/optuna-examples/actions/runs/7845757202

## Description of the changes
Fix wrong import path to `try_import()`, which was brought by https://github.com/optuna/optuna-integration/pull/65. 
`with open optuna_integration._imports.try_import() as _imports:` fails since `optuna_integration._imports` and `_imports` causes name collision (cf. [PEP343](https://peps.python.org/pep-0343/#specification-the-with-statement))
See https://github.com/Alnusjaponica/optuna-examples/pull/3 for the outcome.