### PR TITLE
Remove `UserWarning` by `tests/test_keras.py`

### DIFF
--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -53,7 +53,7 @@ def test_keras_pruning_callback_observation_isnan() -> None:
         callback.on_epoch_end(0, {"loss": 1.0})
 
     with pytest.raises(optuna.TrialPruned):
-        callback.on_epoch_end(0, {"loss": float("nan")})
+        callback.on_epoch_end(1, {"loss": float("nan")})
 
 
 def test_keras_pruning_callback_monitor_is_invalid() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Remove the following warning message by running the keras test.
```shell
$ pytest tests/test_keras.py
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.10.9, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/nzw/Documents/optuna-integration
configfile: pyproject.toml
plugins: anyio-3.7.1
collected 5 items

tests/test_keras.py .....                                                                                                                            [100%]

===================================================================== warnings summary =====================================================================
tests/test_keras.py::test_keras_pruning_callback_observation_isnan
  ...optuna/optuna/trial/_trial.py:493: UserWarning: The reported value is ignored because this `step` 0 is already reported.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

## Description of the changes
<!-- Describe the changes in this PR. -->

Use different `step`.