### PR TITLE
Pass two arguments to the forward of `ConstrainedMCObjective` to support `botorch=0.10.0`

### DIFF
--- a/optuna_integration/botorch.py
+++ b/optuna_integration/botorch.py
@@ -239,7 +239,7 @@ def qei_candidates_func(
 
         n_constraints = train_con.size(1)
         objective = ConstrainedMCObjective(
-            objective=lambda Z: Z[..., 0],
+            objective=lambda Z, X: Z[..., 0],
             constraints=[
                 (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
             ],
@@ -618,7 +618,7 @@ def qparego_candidates_func(
         train_y = torch.cat([train_obj, train_con], dim=-1)
         n_constraints = train_con.size(1)
         objective = ConstrainedMCObjective(
-            objective=lambda Z: scalarization(Z[..., :n_objectives]),
+            objective=lambda Z, X: scalarization(Z[..., :n_objectives]),
             constraints=[
                 (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
             ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ document = [
     "sphinx_rtd_theme",
 ]
 all = [
-  "botorch<0.10.0",
+  "botorch",
   "catalyst",
   "catboost>=0.26; sys_platform!='darwin'",
   "catboost>=0.26,<1.2; sys_platform=='darwin'",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Resolve #97.

## Description of the changes
<!-- Describe the changes in this PR. -->

Revert https://github.com/optuna/optuna-integration/pull/96 and pass two arguments to `ConstrainedMCObjective`'s `forward` that should take two arguments since v0.10.0 by https://github.com/pytorch/botorch/pull/2199 and older botorch supports both one and two arguments. 