### PR TITLE
Install `pipdeptree` v2.16.2 to hotfix parse error

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,8 @@ jobs:
 
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
+        # TODO(not522): Remove a version constraint after resolving pipdeptree problem.
+        pip install pipdeptree==2.16.2
         pipdeptree
 
     - name: black

--- a/.github/workflows/tests-mpi.yml
+++ b/.github/workflows/tests-mpi.yml
@@ -44,7 +44,8 @@ jobs:
 
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
+        # TODO(not522): Remove a version constraint after resolving pipdeptree problem.
+        pip install pipdeptree==2.16.2
         pipdeptree
 
     - name: Tests


### PR DESCRIPTION
## Motivation
The latest `pipdeptree`, v2.17.0, fails to parse version constraints.
https://github.com/optuna/optuna-integration/actions/runs/8562392755/job/23465560814

Note: I think that the cause of this error is the incorrect format of `catalyst`.
https://github.com/catalyst-team/catalyst/blob/v22.04/requirements/requirements-cv.txt#L3

## Description of the changes
Install `pipdeptree` v2.16.2 in CIs.