### PR TITLE
Add trial number to MLflowCallback log_params

### DIFF
--- a/optuna_integration/mlflow.py
+++ b/optuna_integration/mlflow.py
@@ -154,7 +154,7 @@ class MLflowCallback:
                 self._log_metrics(trial.values)
 
                 # This sets the params for MLflow.
-                self._log_params(trial.params)
+                self._log_params(trial)
 
                 # This sets the tags for MLflow.
                 self._set_tags(trial, study)
@@ -313,10 +313,10 @@ class MLflowCallback:
         mlflow.log_metrics(metrics)
 
     @staticmethod
-    def _log_params(params: dict[str, Any]) -> None:
+    def _log_params(trial: optuna.trial.FrozenTrial) -> None:
         """Log the parameters of the trial to MLflow.
 
         Args:
-            params: Trial params.
+            trial: Trial to be logged.
         """
-        mlflow.log_params(params)
+        mlflow.log_params({**trial.params, "number": trial.number})

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -261,7 +261,7 @@ def test_nest_trials(tmpdir: py.path.local) -> None:
     assert len(all_runs) == n_trials + 1
     assert len(child_runs) == n_trials
     assert all(r.data.tags[MLFLOW_PARENT_RUN_ID] == parent_run.info.run_id for r in child_runs)
-    assert all(set(r.data.params.keys()) == {"x", "y", "z"} for r in child_runs)
+    assert all(set(r.data.params.keys()) == {"x", "y", "z", "number"} for r in child_runs)
     assert all(set(r.data.metrics.keys()) == {"value"} for r in child_runs)
 
 


### PR DESCRIPTION
## Motivation

In mlflow we have the capability to create charts based on hpo parameters and metrics, but we are missing the trial number as parameter to for instance create chart of metrics over trials. 

## Description of the changes

With this change we are logging the params just as before but we also add the trial number as parameter
