### PR TITLE
Align run name strategy between MLflowCallback and track_in_mlflow method

### DIFF
--- a/optuna_integration/mlflow.py
+++ b/optuna_integration/mlflow.py
@@ -207,8 +207,9 @@ class MLflowCallback:
                     study = trial.study
                     self._initialize_experiment(study)
                     nested = self._mlflow_kwargs.get("nested")
+                    run_name = self._mlflow_kwargs.get("run_name") or str(trial.number)
 
-                    with mlflow.start_run(run_name=str(trial.number), nested=nested) as run:
+                    with mlflow.start_run(run_name=run_name, nested=nested) as run:
                         trial.storage.set_trial_system_attr(
                             trial._trial_id, RUN_ID_ATTRIBUTE_KEY, run.info.run_id
                         )

--- a/optuna_integration/mlflow.py
+++ b/optuna_integration/mlflow.py
@@ -207,7 +207,7 @@ class MLflowCallback:
                     study = trial.study
                     self._initialize_experiment(study)
                     nested = self._mlflow_kwargs.get("nested")
-                    run_name = self._mlflow_kwargs.get("run_name") or str(trial.number)
+                    run_name = self._mlflow_kwargs.get("run_name", str(trial.number))
 
                     with mlflow.start_run(run_name=run_name, nested=nested) as run:
                         trial.storage.set_trial_system_attr(

--- a/optuna_integration/mlflow.py
+++ b/optuna_integration/mlflow.py
@@ -146,7 +146,7 @@ class MLflowCallback:
             with mlflow.start_run(
                 run_id=trial.system_attrs.get(RUN_ID_ATTRIBUTE_KEY),
                 experiment_id=self._mlflow_kwargs.get("experiment_id"),
-                run_name=self._mlflow_kwargs.get("run_name") or str(trial.number),
+                run_name=self._mlflow_kwargs.get("run_name", str(trial.number)),
                 nested=self._mlflow_kwargs.get("nested") or False,
                 tags=self._mlflow_kwargs.get("tags"),
             ):

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -188,7 +188,9 @@ def test_metric_name_multiobjective(
 def test_run_name(tmpdir: py.path.local, run_name: str | None, expected: str) -> None:
     tracking_uri = f"file:{tmpdir}"
 
-    mlflow_kwargs = {"run_name": run_name}
+    mlflow_kwargs = {}
+    if run_name is not None:
+        mlflow_kwargs = {"run_name": run_name}
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
         mlflc = MLflowCallback(tracking_uri=tracking_uri, mlflow_kwargs=mlflow_kwargs)


### PR DESCRIPTION
## Motivation
The strategy for infering the run name was not aligned between the base class `MLflowCallback` and the decorator `track_in_mlflow`. 

* in MLflowCallback we take the run name given by the user and we fallback to trial number if not given : https://github.com/optuna/optuna-integration/blob/main/optuna_integration/mlflow.py#L149 
* in decorator we take by default trial.number: https://github.com/optuna/optuna-integration/blob/main/optuna_integration/mlflow.py#L211 

## Description of the changes

This PR aligned the strategy to get the run name from MLfowCallback and pass it to mlflow. We lookup `_mlflow_kwargs` and we fallback on trial.number if not given.