### PR TITLE
Remove deprecated `CmaEsSampler` from integration

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -126,7 +126,6 @@ pycma
    :toctree: generated/
    :nosignatures:
 
-   optuna_integration.CmaEsSampler
    optuna_integration.PyCmaSampler
 
 PyTorch

--- a/optuna_integration/__init__.py
+++ b/optuna_integration/__init__.py
@@ -11,7 +11,7 @@ _import_structure = {
     "catboost": ["CatBoostPruningCallback"],
     "chainer": ["ChainerPruningExtension"],
     "chainermn": ["ChainerMNStudy"],
-    "cma": ["CmaEsSampler", "PyCmaSampler"],
+    "cma": ["PyCmaSampler"],
     "dask": ["DaskStorage"],
     "fastaiv2": ["FastAIV2PruningCallback", "FastAIPruningCallback"],
     "keras": ["KerasPruningCallback"],
@@ -39,7 +39,6 @@ __all__ = [
     "CatBoostPruningCallback",
     "ChainerMNStudy",
     "ChainerPruningExtension",
-    "CmaEsSampler",
     "DaskStorage",
     "FastAIPruningCallback",
     "FastAIV2PruningCallback",
@@ -70,7 +69,6 @@ if TYPE_CHECKING:
     from optuna_integration.catboost import CatBoostPruningCallback
     from optuna_integration.chainer import ChainerPruningExtension
     from optuna_integration.chainermn import ChainerMNStudy
-    from optuna_integration.cma import CmaEsSampler
     from optuna_integration.cma import PyCmaSampler
     from optuna_integration.dask import DaskStorage
     from optuna_integration.fastaiv2 import FastAIPruningCallback

--- a/optuna_integration/cma/__init__.py
+++ b/optuna_integration/cma/__init__.py
@@ -1,5 +1,4 @@
-from .cma import CmaEsSampler
 from .cma import PyCmaSampler
 
 
-__all__ = ["PyCmaSampler", "CmaEsSampler"]
+__all__ = ["PyCmaSampler"]

--- a/optuna_integration/cma/cma.py
+++ b/optuna_integration/cma/cma.py
@@ -44,8 +44,8 @@ class PyCmaSampler(BaseSampler):
     especially if the number of trials running in parallel exceeds the population size.
 
     .. note::
-        :class:`~optuna_integration.CmaEsSampler` is deprecated and renamed to
-        :class:`~optuna_integration.PyCmaSampler` in v2.0.0. Please use
+        :class:`~optuna_integration.CmaEsSampler` was renamed to
+        :class:`~optuna_integration.PyCmaSampler` in v4.0.0. Please use
         :class:`~optuna_integration.PyCmaSampler` instead of
         :class:`~optuna_integration.CmaEsSampler`.
 

--- a/optuna_integration/cma/cma.py
+++ b/optuna_integration/cma/cma.py
@@ -32,8 +32,6 @@ _logger = logging.get_logger(__name__)
 
 _EPS = 1e-10
 
-_cma_deprecated_msg = "This class is renamed to :class:`~optuna_integration.PyCmaSampler`."
-
 
 class PyCmaSampler(BaseSampler):
     """A Sampler using cma library as the backend.
@@ -468,30 +466,3 @@ class _Optimizer:
             v = int(numpy.round(cma_param_value))
             return dist.choices[v]
         return cma_param_value
-
-
-@deprecated_class("2.0.0", "4.0.0", text=_cma_deprecated_msg)
-class CmaEsSampler(PyCmaSampler):
-    """Wrapper class of PyCmaSampler for backward compatibility."""
-
-    def __init__(
-        self,
-        x0: Optional[Dict[str, Any]] = None,
-        sigma0: Optional[float] = None,
-        cma_stds: Optional[Dict[str, float]] = None,
-        seed: Optional[int] = None,
-        cma_opts: Optional[Dict[str, Any]] = None,
-        n_startup_trials: int = 1,
-        independent_sampler: Optional[BaseSampler] = None,
-        warn_independent_sampling: bool = True,
-    ) -> None:
-        super().__init__(
-            x0=x0,
-            sigma0=sigma0,
-            cma_stds=cma_stds,
-            seed=seed,
-            cma_opts=cma_opts,
-            n_startup_trials=n_startup_trials,
-            independent_sampler=independent_sampler,
-            warn_independent_sampling=warn_independent_sampling,
-        )

--- a/tests/cma/test_cma.py
+++ b/tests/cma/test_cma.py
@@ -27,11 +27,6 @@ with try_import():
     import cma
 
 
-def test_cmaes_deprecation_warning() -> None:
-    with pytest.warns(FutureWarning):
-        optuna_integration.CmaEsSampler()
-
-
 class TestPyCmaSampler:
     @staticmethod
     def test_init_cma_opts() -> None:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I want to remove deprecated `CmaEsSampler` from integration. This PR does not affect `optuna/sampler/_cmaes.py`.

This PR is related to PR https://github.com/optuna/optuna/pull/1325 and https://github.com/optuna/optuna/pull/5417 .

## Description of the changes
<!-- Describe the changes in this PR. -->

I removed `CmaEsSampler` from integration.