### PR TITLE
Pass two arguments to the forward of `ConstrainedMCObjective` in `qnei_candidates_func`

### DIFF
--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -309,7 +309,7 @@ def qnei_candidates_func(
 
         n_constraints = train_con.size(1)
         objective = ConstrainedMCObjective(
-            objective=lambda Z: Z[..., 0],
+            objective=lambda Z, X: Z[..., 0],
             constraints=[
                 (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
             ],

--- a/tests/botorch/test_botorch.py
+++ b/tests/botorch/test_botorch.py
@@ -139,6 +139,7 @@ def test_botorch_specify_candidates_func(candidates_func: Any, n_objectives: int
     [
         (integration.botorch.logei_candidates_func, 1),
         (integration.botorch.qei_candidates_func, 1),
+        (integration.botorch.qnei_candidates_func, 1),
         (integration.botorch.qehvi_candidates_func, 2),
         (integration.botorch.qparego_candidates_func, 4),
         (integration.botorch.qnehvi_candidates_func, 2),


### PR DESCRIPTION
## Motivation
Fixes `BoTorchSampler` when using `qnei_candidates_func` on problems with constraints.

## Description of the changes
Applies the same fix in #106 to `qnei_candidates_func` (it seems that this candidate function was missed).

Also updates the tests to include `qnei_candidates_func`, which would have caught this bug.
