### PR TITLE
Allow single split cv in `OptunaSearchCV`

### DIFF
--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -12,6 +12,7 @@ from time import time
 from typing import Any
 from typing import List
 from typing import Union
+import warnings
 
 import numpy as np
 from optuna import distributions
@@ -263,7 +264,13 @@ class _Objective:
 
         test_scores = scores["test_score"]
         scores_list = test_scores if isinstance(test_scores, list) else test_scores.tolist()
-        report_cross_validation_scores(trial, scores_list)
+        try:
+            report_cross_validation_scores(trial, scores_list)
+        except ValueError as e:
+            warn_msg = (
+                "Failed to report cross validation scores for TerminatorCallback, with error: {}"
+            ).format(e)
+            warnings.warn(warn_msg)
 
         return trial.user_attrs["mean_test_score"]
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Using sklearn's CV splitter which results in a single split, e.g. `PredefinedSplit`, causes `OptunaSearchCV` to fail to report the test scores. The reported scores are used for the default implementation of the `TerminatorCallback`. However, the error is raised irrespective of the presence of this callback. As a result, the `OptunaSearchCV` is unnecessarily unusable when a single split CV is provided and no callback relies on reported scores.

## Description of the changes
<!-- Describe the changes in this PR. -->

Instead of raising the ValueError in `OptunaSearchCV`, which interrupts the fit, a warning is raised, explaining the problem to the user and forwarding the error message. It is up to the user to decide whether action is required and the fit continues on default. If this causes errors downstream, the warning should aid the user in understanding and fixing the issue quickly.
