### PR TITLE
Update BoTorch samplers to support new constraints interface

### DIFF
--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -37,7 +37,6 @@ with try_import() as _imports:
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
     from botorch.acquisition.objective import GenericMCObjective
-    from botorch.acquisition.objective import MCAcquisitionObjective
     from botorch.models import ModelListGP
     from botorch.models import SingleTaskGP
     from botorch.models.transforms.outcome import Standardize
@@ -240,7 +239,7 @@ def qei_candidates_func(
             raise ImportError(
                 "qei_candidates_func requires botorch >=0.9.0. for constrained problems."
                 "Please upgrade botorch"
-            )       
+            )
         train_y = torch.cat([train_obj, train_con], dim=-1)
 
         is_feas = (train_con <= 0).all(dim=-1)

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -271,9 +271,7 @@ def qei_candidates_func(
         n_constraints = train_con.size(1)
         objective, kwargs = _create_objective_and_kwargs(
             objective=lambda Z, X: Z[..., 0],
-            constraints=[
-                (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
-            ],
+            constraints=[lambda Z: Z[..., -n_constraints + i] for i in range(n_constraints)],
         )
     else:
         train_y = train_obj
@@ -343,9 +341,7 @@ def qnei_candidates_func(
         n_constraints = train_con.size(1)
         objective, kwargs = _create_objective_and_kwargs(
             objective=lambda Z, X: Z[..., 0],
-            constraints=[
-                (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
-            ],
+            constraints=[lambda Z: Z[..., -n_constraints + i] for i in range(n_constraints)],
         )
     else:
         train_y = train_obj
@@ -417,9 +413,7 @@ def qehvi_candidates_func(
         n_constraints = train_con.size(1)
         additional_qehvi_kwargs = {
             "objective": IdentityMCMultiOutputObjective(outcomes=list(range(n_objectives))),
-            "constraints": [
-                (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
-            ],
+            "constraints": [lambda Z: Z[..., -n_constraints + i] for i in range(n_constraints)],
         }
     else:
         train_y = train_obj
@@ -654,9 +648,7 @@ def qparego_candidates_func(
         n_constraints = train_con.size(1)
         objective, kwargs = _create_objective_and_kwargs(
             objective=lambda Z, X: scalarization(Z[..., :n_objectives]),
-            constraints=[
-                (lambda Z, i=i: Z[..., -n_constraints + i]) for i in range(n_constraints)
-            ],
+            constraints=[lambda Z: Z[..., -n_constraints + i] for i in range(n_constraints)],
         )
     else:
         train_y = train_obj

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -255,8 +255,8 @@ def qei_candidates_func(
             best_f = train_obj_feas.max()
 
         n_constraints = train_con.size(1)
-        objective = GenericMCObjective(lambda Z, X: Z[..., 0])
-        kwargs = {
+        additonal_qei_kwargs = {
+            "objective": GenericMCObjective(lambda Z, X: Z[..., 0]),
             "constraints": [lambda Z: Z[..., -n_constraints + i] for i in range(n_constraints)],
         }
     else:
@@ -264,8 +264,7 @@ def qei_candidates_func(
 
         best_f = train_obj.max()
 
-        objective = None  # Using the default identity objective.
-        kwargs = {}
+        additonal_qei_kwargs = {}
 
     train_x = normalize(train_x, bounds=bounds)
     if pending_x is not None:
@@ -279,9 +278,8 @@ def qei_candidates_func(
         model=model,
         best_f=best_f,
         sampler=_get_sobol_qmc_normal_sampler(256),
-        objective=objective,
         X_pending=pending_x,
-        **kwargs,
+        **additonal_qei_kwargs,
     )
 
     standard_bounds = torch.zeros_like(bounds)
@@ -330,15 +328,14 @@ def qnei_candidates_func(
         train_y = torch.cat([train_obj, train_con], dim=-1)
 
         n_constraints = train_con.size(1)
-        objective = GenericMCObjective(lambda Z, X: Z[..., 0])
-        kwargs = {
+        additional_qnei_kwargs = {
+            "objective": GenericMCObjective(lambda Z, X: Z[..., 0]),
             "constraints": [lambda Z: Z[..., -n_constraints + i] for i in range(n_constraints)],
         }
     else:
         train_y = train_obj
 
-        objective = None  # Using the default identity objective.
-        kwargs = {}
+        additional_qnei_kwargs = {}
 
     train_x = normalize(train_x, bounds=bounds)
     if pending_x is not None:
@@ -352,9 +349,8 @@ def qnei_candidates_func(
         model=model,
         X_baseline=train_x,
         sampler=_get_sobol_qmc_normal_sampler(256),
-        objective=objective,
         X_pending=pending_x,
-        **kwargs,
+        **additional_qnei_kwargs,
     )
 
     standard_bounds = torch.zeros_like(bounds)
@@ -644,14 +640,14 @@ def qparego_candidates_func(
         train_y = torch.cat([train_obj, train_con], dim=-1)
         n_constraints = train_con.size(1)
         objective = GenericMCObjective(lambda Z, X: scalarization(Z[..., :n_objectives]))
-        kwargs = {
+        additional_kwargs = {
             "constraints": [lambda Z: Z[..., -n_constraints + i] for i in range(n_constraints)],
         }
     else:
         train_y = train_obj
 
         objective = GenericMCObjective(scalarization)
-        kwargs = {}
+        additional_kwargs = {}
 
     train_x = normalize(train_x, bounds=bounds)
     if pending_x is not None:
@@ -667,7 +663,7 @@ def qparego_candidates_func(
         sampler=_get_sobol_qmc_normal_sampler(256),
         objective=objective,
         X_pending=pending_x,
-        **kwargs,
+        **additional_kwargs,
     )
 
     standard_bounds = torch.zeros_like(bounds)

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -1,10 +1,10 @@
 from typing import Any
-from typing import Tuple
 from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 from typing import Union
 import warnings
 
@@ -37,9 +37,9 @@ with try_import() as _imports:
         FeasibilityWeightedMCMultiOutputObjective,
     )
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
-    from botorch.acquisition.objective import MCAcquisitionObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
     from botorch.acquisition.objective import GenericMCObjective
+    from botorch.acquisition.objective import MCAcquisitionObjective
     from botorch.models import ModelListGP
     from botorch.models import SingleTaskGP
     from botorch.models.transforms.outcome import Standardize

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -297,7 +297,7 @@ def qei_candidates_func(
         sampler=_get_sobol_qmc_normal_sampler(256),
         objective=objective,
         X_pending=pending_x,
-        **kwargs
+        **kwargs,
     )
 
     standard_bounds = torch.zeros_like(bounds)
@@ -367,7 +367,7 @@ def qnei_candidates_func(
         sampler=_get_sobol_qmc_normal_sampler(256),
         objective=objective,
         X_pending=pending_x,
-        **kwargs
+        **kwargs,
     )
 
     standard_bounds = torch.zeros_like(bounds)
@@ -678,7 +678,7 @@ def qparego_candidates_func(
         sampler=_get_sobol_qmc_normal_sampler(256),
         objective=objective,
         X_pending=pending_x,
-        **kwargs
+        **kwargs,
     )
 
     standard_bounds = torch.zeros_like(bounds)

--- a/tests/botorch/test_botorch.py
+++ b/tests/botorch/test_botorch.py
@@ -163,6 +163,13 @@ def test_botorch_specify_candidates_func_constrained(
     ) < version.parse("0.9.5"):
         pytest.skip("qHypervolumeKnowledgeGradient is not available in botorch <0.9.5.")
 
+    if candidates_func in [
+        integration.botorch.qei_candidates_func,
+        integration.botorch.qnei_candidates_func,
+        integration.botorch.qparego_candidates_func,
+    ] and version.parse(botorch.version.version) < version.parse("0.9.0"):
+        pytest.skip("MC EI acquisition functions require botorch >=0.9.0.")
+
     n_trials = 4
     n_startup_trials = 2
     constraints_func_call_count = 0


### PR DESCRIPTION
## Motivation

Improves the way constraints are handled by the BoTorch sampler.

## Description of the changes

Updates the candidates functions to pass the constraints directly to the acquisition function as was introduced in pytorch/botorch#1791. This can improve performance, by less harshly penalising infeasible solutions which may lead to an overall improvement, as well as avoid numerical problems.

- [x] Update candidate functions
- [x] Add comparison before and other this change
