### PR TITLE
Remove verbosity of `LightGBMTuner`

### DIFF
--- a/optuna_integration/_lightgbm_tuner/_train.py
+++ b/optuna_integration/_lightgbm_tuner/_train.py
@@ -31,7 +31,6 @@ def train(
     study: Study | None = None,
     optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
     model_dir: str | None = None,
-    verbosity: int | None = None,
     show_progress_bar: bool = True,
     *,
     optuna_seed: int | None = None,
@@ -82,17 +81,6 @@ def train(
             exist, it will be created. The filenames of the boosters will be
             ``{model_dir}/{trial_number}.pkl`` (e.g., ``./boosters/0.pkl``).
 
-        verbosity:
-            A verbosity level to change Optuna's logging level. The level is aligned to
-            `LightGBM's verbosity`_ .
-
-            .. warning::
-                Deprecated in v2.0.0. ``verbosity`` argument will be removed in the future.
-                The removal of this feature is currently scheduled for v4.0.0,
-                but this schedule is subject to change.
-
-                Please use :func:`~optuna.logging.set_verbosity` instead.
-
         show_progress_bar:
             Flag to show progress bars or not. To disable progress bar, set this :obj:`False`.
 
@@ -131,7 +119,6 @@ def train(
         study=study,
         optuna_callbacks=optuna_callbacks,
         model_dir=model_dir,
-        verbosity=verbosity,
         show_progress_bar=show_progress_bar,
         optuna_seed=optuna_seed,
     )

--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -363,7 +363,6 @@ class _LightGBMBaseTuner(_BaseTuner):
         sample_size: int | None = None,
         study: optuna.study.Study | None = None,
         optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
-        verbosity: int | None = None,
         show_progress_bar: bool = True,
         model_dir: str | None = None,
         *,
@@ -384,7 +383,6 @@ class _LightGBMBaseTuner(_BaseTuner):
             callbacks=callbacks,
             time_budget=time_budget,
             sample_size=sample_size,
-            verbosity=verbosity,
             show_progress_bar=show_progress_bar,
         )
         self._parse_args(*args, **kwargs)
@@ -425,15 +423,6 @@ class _LightGBMBaseTuner(_BaseTuner):
                     "Please set 'minimize' as the direction."
                 )
 
-        if verbosity is not None:
-            warnings.warn(
-                "`verbosity` argument is deprecated and will be removed in the future. "
-                "The removal of this feature is currently scheduled for v4.0.0, "
-                "but this schedule is subject to change. Please use optuna.logging.set_verbosity()"
-                " instead.",
-                FutureWarning,
-            )
-
         if self._model_dir is not None and not os.path.exists(self._model_dir):
             os.mkdir(self._model_dir)
 
@@ -461,7 +450,7 @@ class _LightGBMBaseTuner(_BaseTuner):
     def _parse_args(self, *args: Any, **kwargs: Any) -> None:
         self.auto_options = {
             option_name: kwargs.get(option_name)
-            for option_name in ["time_budget", "sample_size", "verbosity", "show_progress_bar"]
+            for option_name in ["time_budget", "sample_size", "show_progress_bar"]
         }
 
         # Split options.
@@ -476,16 +465,6 @@ class _LightGBMBaseTuner(_BaseTuner):
 
     def run(self) -> None:
         """Perform the hyperparameter-tuning with given parameters."""
-        verbosity = self.auto_options["verbosity"]
-        if verbosity is not None:
-            if verbosity > 1:
-                optuna.logging.set_verbosity(optuna.logging.DEBUG)
-            elif verbosity == 1:
-                optuna.logging.set_verbosity(optuna.logging.INFO)
-            elif verbosity == 0:
-                optuna.logging.set_verbosity(optuna.logging.WARNING)
-            else:
-                optuna.logging.set_verbosity(optuna.logging.CRITICAL)
 
         # Handling aliases.
         _handling_alias_parameters(self.lgbm_params)
@@ -719,17 +698,6 @@ class LightGBMTuner(_LightGBMBaseTuner):
             exist, it will be created. The filenames of the boosters will be
             ``{model_dir}/{trial_number}.pkl`` (e.g., ``./boosters/0.pkl``).
 
-        verbosity:
-            A verbosity level to change Optuna's logging level. The level is aligned to
-            `LightGBM's verbosity`_ .
-
-            .. warning::
-                Deprecated in v2.0.0. ``verbosity`` argument will be removed in the future.
-                The removal of this feature is currently scheduled for v4.0.0,
-                but this schedule is subject to change.
-
-                Please use :func:`~optuna.logging.set_verbosity` instead.
-
         show_progress_bar:
             Flag to show progress bars or not. To disable progress bar, set this :obj:`False`.
 
@@ -768,7 +736,6 @@ class LightGBMTuner(_LightGBMBaseTuner):
         study: optuna.study.Study | None = None,
         optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
         model_dir: str | None = None,
-        verbosity: int | None = None,
         show_progress_bar: bool = True,
         *,
         optuna_seed: int | None = None,
@@ -785,7 +752,6 @@ class LightGBMTuner(_LightGBMBaseTuner):
             sample_size=sample_size,
             study=study,
             optuna_callbacks=optuna_callbacks,
-            verbosity=verbosity,
             show_progress_bar=show_progress_bar,
             model_dir=model_dir,
             optuna_seed=optuna_seed,
@@ -904,17 +870,6 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
             created. The filenames of the boosters will be ``{model_dir}/{trial_number}.pkl``
             (e.g., ``./boosters/0.pkl``).
 
-        verbosity:
-            A verbosity level to change Optuna's logging level. The level is aligned to
-            `LightGBM's verbosity`_ .
-
-            .. warning::
-                Deprecated in v2.0.0. ``verbosity`` argument will be removed in the future.
-                The removal of this feature is currently scheduled for v4.0.0,
-                but this schedule is subject to change.
-
-                Please use :func:`~optuna.logging.set_verbosity` instead.
-
         show_progress_bar:
             Flag to show progress bars or not. To disable progress bar, set this :obj:`False`.
 
@@ -964,7 +919,6 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
         sample_size: int | None = None,
         study: optuna.study.Study | None = None,
         optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
-        verbosity: int | None = None,
         show_progress_bar: bool = True,
         model_dir: str | None = None,
         return_cvbooster: bool = False,
@@ -983,7 +937,6 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
             sample_size=sample_size,
             study=study,
             optuna_callbacks=optuna_callbacks,
-            verbosity=verbosity,
             show_progress_bar=show_progress_bar,
             model_dir=model_dir,
             optuna_seed=optuna_seed,

--- a/tests/lightgbm/test_optimize.py
+++ b/tests/lightgbm/test_optimize.py
@@ -280,7 +280,7 @@ class TestLightGBMTuner:
         dummy_dataset = lgb.Dataset(None)
 
         with pytest.warns(FutureWarning):
-            LightGBMTuner({}, dummy_dataset, valid_sets=[dummy_dataset], verbosity=1)
+            LightGBMTuner({}, dummy_dataset, valid_sets=[dummy_dataset])
 
     def test_no_eval_set_args(self) -> None:
         params: dict[str, Any] = {}
@@ -542,44 +542,6 @@ class TestLightGBMTuner:
             tuner2.tune_regularization_factors()
         assert n_trials == len(study.trials)
 
-    @pytest.mark.parametrize(
-        "verbosity, level",
-        [
-            (None, optuna.logging.INFO),
-            (-2, optuna.logging.CRITICAL),
-            (-1, optuna.logging.CRITICAL),
-            (0, optuna.logging.WARNING),
-            (1, optuna.logging.INFO),
-            (2, optuna.logging.DEBUG),
-        ],
-    )
-    def test_run_verbosity(self, verbosity: int, level: int) -> None:
-        # We need to reconstruct our default handler to properly capture stderr.
-        optuna.logging._reset_library_root_logger()
-        optuna.logging.set_verbosity(optuna.logging.INFO)
-
-        params: dict = {"verbose": -1}
-        dataset = lgb.Dataset(np.zeros((10, 10)))
-
-        study = optuna.create_study()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=FutureWarning)
-            tuner = LightGBMTuner(
-                params,
-                dataset,
-                valid_sets=dataset,
-                study=study,
-                verbosity=verbosity,
-                callbacks=[log_evaluation(-1)],
-                time_budget=1,
-            )
-
-        with mock.patch.object(_BaseTuner, "_get_booster_best_score", return_value=1.0):
-            tuner.run()
-
-        assert optuna.logging.get_verbosity() == level
-        assert tuner.lgbm_params["verbose"] == -1
-
     @pytest.mark.parametrize("show_progress_bar, expected", [(True, 6), (False, 0)])
     def test_run_show_progress_bar(self, show_progress_bar: bool, expected: int) -> None:
         params: dict = {"verbose": -1}
@@ -795,7 +757,7 @@ class TestLightGBMTunerCV:
         dummy_dataset = lgb.Dataset(None)
 
         with pytest.warns(FutureWarning):
-            LightGBMTunerCV({}, dummy_dataset, verbosity=1)
+            LightGBMTunerCV({}, dummy_dataset)
 
     @pytest.mark.parametrize(
         "metric, study_direction",
@@ -922,38 +884,6 @@ class TestLightGBMTunerCV:
         with mock.patch.object(_OptunaObjectiveCV, "_get_cv_scores", return_value=[1.0]):
             tuner2.tune_regularization_factors()
         assert n_trials == len(study.trials)
-
-    @pytest.mark.parametrize(
-        "verbosity, level",
-        [
-            (None, optuna.logging.INFO),
-            (-2, optuna.logging.CRITICAL),
-            (-1, optuna.logging.CRITICAL),
-            (0, optuna.logging.WARNING),
-            (1, optuna.logging.INFO),
-            (2, optuna.logging.DEBUG),
-        ],
-    )
-    def test_run_verbosity(self, verbosity: int, level: int) -> None:
-        # We need to reconstruct our default handler to properly capture stderr.
-        optuna.logging._reset_library_root_logger()
-        optuna.logging.set_verbosity(optuna.logging.INFO)
-
-        params: dict = {"verbose": -1}
-        dataset = lgb.Dataset(np.zeros((10, 10)))
-
-        study = optuna.create_study()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=FutureWarning)
-            tuner = LightGBMTunerCV(
-                params, dataset, study=study, verbosity=verbosity, time_budget=1
-            )
-
-        with mock.patch.object(_OptunaObjectiveCV, "_get_cv_scores", return_value=[1.0]):
-            tuner.run()
-
-        assert optuna.logging.get_verbosity() == level
-        assert tuner.lgbm_params["verbose"] == -1
 
     @pytest.mark.parametrize("show_progress_bar, expected", [(True, 6), (False, 0)])
     def test_run_show_progress_bar(self, show_progress_bar: bool, expected: int) -> None:

--- a/tests/lightgbm/test_optimize.py
+++ b/tests/lightgbm/test_optimize.py
@@ -276,12 +276,6 @@ class TestLightGBMTuner:
         )
         return runner
 
-    def test_deprecated_args(self) -> None:
-        dummy_dataset = lgb.Dataset(None)
-
-        with pytest.warns(FutureWarning):
-            LightGBMTuner({}, dummy_dataset, valid_sets=[dummy_dataset])
-
     def test_no_eval_set_args(self) -> None:
         params: dict[str, Any] = {}
         train_set = lgb.Dataset(None)
@@ -752,12 +746,6 @@ class TestLightGBMTunerCV:
             params, train_set, callbacks=[early_stopping(stopping_rounds=2)], **kwargs
         )
         return runner
-
-    def test_deprecated_args(self) -> None:
-        dummy_dataset = lgb.Dataset(None)
-
-        with pytest.warns(FutureWarning):
-            LightGBMTunerCV({}, dummy_dataset)
 
     @pytest.mark.parametrize(
         "metric, study_direction",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the verbosity of `LightGBMTuner` is deprecated, I removed the argument.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Remove the `verbosity` argument