### PR TITLE
Move positional args of LightGBM tuner

### DIFF
--- a/optuna_integration/__init__.py
+++ b/optuna_integration/__init__.py
@@ -71,8 +71,8 @@ if TYPE_CHECKING:
     from optuna_integration.catboost import CatBoostPruningCallback
     from optuna_integration.chainer import ChainerPruningExtension
     from optuna_integration.chainermn import ChainerMNStudy
-    from optuna_integration.comet import CometCallback
     from optuna_integration.cma import PyCmaSampler
+    from optuna_integration.comet import CometCallback
     from optuna_integration.dask import DaskStorage
     from optuna_integration.fastaiv2 import FastAIPruningCallback
     from optuna_integration.fastaiv2 import FastAIV2PruningCallback

--- a/optuna_integration/_lightgbm_tuner/_train.py
+++ b/optuna_integration/_lightgbm_tuner/_train.py
@@ -31,8 +31,8 @@ def train(
     study: Study | None = None,
     optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
     model_dir: str | None = None,
-    show_progress_bar: bool = True,
     *,
+    show_progress_bar: bool = True,
     optuna_seed: int | None = None,
 ) -> "lgb.Booster":
     """Wrapper of LightGBM Training API to tune hyperparameters.

--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -363,9 +363,9 @@ class _LightGBMBaseTuner(_BaseTuner):
         sample_size: int | None = None,
         study: optuna.study.Study | None = None,
         optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
+        *,
         show_progress_bar: bool = True,
         model_dir: str | None = None,
-        *,
         optuna_seed: int | None = None,
     ) -> None:
         _imports.check()
@@ -736,8 +736,8 @@ class LightGBMTuner(_LightGBMBaseTuner):
         study: optuna.study.Study | None = None,
         optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
         model_dir: str | None = None,
-        show_progress_bar: bool = True,
         *,
+        show_progress_bar: bool = True,
         optuna_seed: int | None = None,
     ) -> None:
         super().__init__(
@@ -919,10 +919,10 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
         sample_size: int | None = None,
         study: optuna.study.Study | None = None,
         optuna_callbacks: list[Callable[[Study, FrozenTrial], None]] | None = None,
+        *,
         show_progress_bar: bool = True,
         model_dir: str | None = None,
         return_cvbooster: bool = False,
-        *,
         optuna_seed: int | None = None,
     ) -> None:
         super().__init__(

--- a/tests/lightgbm/test_optimize.py
+++ b/tests/lightgbm/test_optimize.py
@@ -6,7 +6,6 @@ from tempfile import TemporaryDirectory
 from typing import Any
 from typing import TYPE_CHECKING
 from unittest import mock
-import warnings
 
 import numpy as np
 import optuna


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As `verbosity`, which is a positional arg, was removed from LightGBM tuner and it slides the positional arg order, I made args after `verbosity` as keyword args only.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Move the location of `*`
