### PR TITLE
Remove duplicated license definition.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 name = "optuna-integration"
 description = "Integration libraries of Optuna."
 readme = "README.md"
-license = { file = "LICENSE" }
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Motivation

- Similar to https://github.com/optuna/optuna/pull/5645

Currently, the license was shown in PyPI as follows:
<img width="282" alt="image" src="https://github.com/user-attachments/assets/fe8e978e-cf07-4719-bb77-bb8967e353ef">


## Description of the changes

- Remove duplicated license definition

