### PR TITLE
Update sklearn.py by addind catch to OptunaSearchCV

### DIFF
--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -502,8 +502,9 @@ class OptunaSearchCV(BaseEstimator):
                 for how to use and implement callback functions.
 
         catch:
-            Tuple of exceptions to catch such that a study continues to run even when a trial raises one of the exceptions specified in this argument.
-            Default is an empty tuple, i.e. the study will stop for any exception except for :class:`~optuna.exceptions.TrialPruned`.
+            A study continues to run even when a trial raises one of the exceptions specified
+            in this argument. Default is an empty tuple, i.e. the study will stop for any
+            exception except for :class:`~optuna.exceptions.TrialPruned`.
 
     Attributes:
         best_estimator_:

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -501,6 +501,10 @@ class OptunaSearchCV(BaseEstimator):
                 See the tutorial of `Callback for Study.optimize <https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/007_optuna_callback.html#optuna-callback>`_
                 for how to use and implement callback functions.
 
+        catch:
+            Tuple of exceptions to catch such that a study continues to run even when a trial raises one of the exceptions specified in this argument.
+            Default is an empty tuple, i.e. the study will stop for any exception except for :class:`~optuna.exceptions.TrialPruned`.
+
     Attributes:
         best_estimator_:
             Estimator that was chosen by the search. This is present only if

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -733,6 +733,7 @@ class OptunaSearchCV(BaseEstimator):
         timeout: float | None = None,
         verbose: int = 0,
         callbacks: list[Callable[[study_module.Study, FrozenTrial], None]] | None = None,
+        catch: Iterable[type[Exception]] | type[Exception] = (),
     ) -> None:
         _imports.check()
 
@@ -767,6 +768,7 @@ class OptunaSearchCV(BaseEstimator):
         self.timeout = timeout
         self.verbose = verbose
         self.callbacks = callbacks
+        self.catch = catch
 
     def _check_is_fitted(self) -> None:
         attributes = ["n_splits_", "sample_indices_", "scorer_", "study_"]
@@ -925,6 +927,7 @@ class OptunaSearchCV(BaseEstimator):
             n_trials=self.n_trials,
             timeout=self.timeout,
             callbacks=self.callbacks,
+            catch=self.catch,
         )
 
         _logger.info("Finished hyperparameter search!")

--- a/tests/sklearn/test_sklearn.py
+++ b/tests/sklearn/test_sklearn.py
@@ -461,17 +461,17 @@ def test_callbacks() -> None:
 
 
 @pytest.mark.parametrize("catch", [(ValueError,), ()])
-def test_catch(catch):
+def test_catch(catch) -> None:
 
     class MockDististribution(distributions.BaseDistribution):
 
-        def _contains(self):
+        def _contains(self) -> None:  # type: ignore
             return ValueError
 
-        def single(self):
+        def single(self) -> None:  # type: ignore
             raise ValueError
 
-        def to_internal_repr(self):
+        def to_internal_repr(self) -> None:  # type: ignore
             raise ValueError
 
     est = SGDClassifier(max_iter=5, tol=1e-03)

--- a/tests/sklearn/test_sklearn.py
+++ b/tests/sklearn/test_sklearn.py
@@ -459,7 +459,7 @@ def test_callbacks() -> None:
         assert callback.call_count == n_trials
 
 
-@pytest.mark.parametrize("catch", [(ValueError, ), ()])
+@pytest.mark.parametrize("catch", [(ValueError,), ()])
 def test_catch(catch):
 
     class MockDististribution(distributions.BaseDistribution):

--- a/tests/sklearn/test_sklearn.py
+++ b/tests/sklearn/test_sklearn.py
@@ -461,12 +461,12 @@ def test_callbacks() -> None:
 
 
 @pytest.mark.parametrize("catch", [(ValueError,), ()])
-def test_catch(catch) -> None:
+def test_catch(catch: tuple) -> None:
 
     class MockDististribution(distributions.BaseDistribution):
 
         def _contains(self) -> None:  # type: ignore
-            return ValueError
+            raise ValueError
 
         def single(self) -> None:  # type: ignore
             raise ValueError

--- a/tests/sklearn/test_sklearn.py
+++ b/tests/sklearn/test_sklearn.py
@@ -24,8 +24,9 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import SGDClassifier
+from sklearn.metrics import make_scorer
+from sklearn.metrics import r2_score
 from sklearn.model_selection import PredefinedSplit
-from sklearn.metrics import r2_score, make_scorer
 from sklearn.neighbors import KernelDensity
 from sklearn.tree import DecisionTreeRegressor
 


### PR DESCRIPTION
To allow for catching exceptions during fit, an init param for "catch" is added, which is passed to self.study_.optimize

## Motivation
`catch` was previously not passed to `self.study_.optimize`, meaning that there was no way to catch exceptions at fit time (see issue: https://github.com/optuna/optuna-integration/issues/162

## Description of the changes
Simply adding an init parameter called `catch`, which is then passed to `self.study_.optimize`
