### PR TITLE
Fix CI for fastaiv2

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -119,6 +119,7 @@ jobs:
     with:
       integration_name: 'fastaiv2'
       deprecated: false
+      python_matrix: "['3.9', '3.10', '3.11']"
 
   keras:
     if: needs.changes.outputs.keras == 'true'

--- a/.github/workflows/checks_template.yml
+++ b/.github/workflows/checks_template.yml
@@ -12,6 +12,10 @@ on:
       extra_cmds:
         required: false
         type: string
+      python_matrix:
+        required: false
+        type: string
+        default: "['3.8', '3.9', '3.10', '3.11']"
 jobs:
   checks:
     runs-on: ubuntu-latest
@@ -74,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ${{ fromJSON(inputs.python_matrix) }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5


### PR DESCRIPTION
## Motivation & Description of the changes

The latest fastai requires numpy >= 2.0 that does not work on Python < 3.9.
This PR disables the fastai CI for Python < 3.9.