### PR TITLE
Fix mlflow integration for CI

### DIFF
--- a/optuna_integration/mlflow/mlflow.py
+++ b/optuna_integration/mlflow/mlflow.py
@@ -153,7 +153,7 @@ class MLflowCallback:
                 with self._lock:
                     study = trial.study
                     self._initialize_experiment(study)
-                    nested = self._mlflow_kwargs.get("nested")
+                    nested = bool(self._mlflow_kwargs.get("nested"))
                     run_name = self._mlflow_kwargs.get("run_name", str(trial.number))
 
                     with mlflow.start_run(run_name=run_name, nested=nested) as run:

--- a/tests/mlflow/test_mlflow.py
+++ b/tests/mlflow/test_mlflow.py
@@ -235,7 +235,7 @@ def test_tag_truncation(tmpdir: py.path.local) -> None:
     first_run_dict = first_run.to_dictionary()
 
     my_user_attr = first_run_dict["data"]["tags"]["my_user_attr"]
-    assert len(my_user_attr) <= 5000
+    assert len(my_user_attr) <= 8000
 
 
 def test_nest_trials(tmpdir: py.path.local) -> None:

--- a/tests/mlflow/test_mlflow.py
+++ b/tests/mlflow/test_mlflow.py
@@ -127,6 +127,7 @@ def test_use_existing_experiment_by_id(tmpdir: py.path.local) -> None:
     assert experiment.experiment_id == experiment_id
     assert experiment.name == "foo"
 
+    # TODO(y0z): Remove type ignore once the MLFlow typing is fixed.
     runs = mlfl_client.search_runs(experiment_id)  # type: ignore
     assert len(runs) == 10
 

--- a/tests/mlflow/test_mlflow.py
+++ b/tests/mlflow/test_mlflow.py
@@ -127,7 +127,7 @@ def test_use_existing_experiment_by_id(tmpdir: py.path.local) -> None:
     assert experiment.experiment_id == experiment_id
     assert experiment.name == "foo"
 
-    runs = mlfl_client.search_runs(experiment_id)
+    runs = mlfl_client.search_runs(experiment_id)  # type: ignore
     assert len(runs) == 10
 
 


### PR DESCRIPTION
## Motivation

This PR fixes CI errors in the mlflow integration.

## Description of the changes

- Add an explicit conversion to bool.
- Increase `len(my_user_attr)` limit to 8000 following the change of mlflow (https://github.com/mlflow/mlflow/commit/da8a91edb8843e1161702c00be45a5937c8272f0).
- Set "type: ignore" in L130 to avoid error due to an invalid type hint in https://github.com/mlflow/mlflow/blob/0862ba2c42263e11f6058a73d4ff2b885f176241/mlflow/tracking/client.py#L2969-L2980 (experiment_ids: List of experiment IDs, or a single int or string id but its type hint is List[str]).