### PR TITLE
Improve `OptunaSearchCV` (accept `Mapping` in addition to `dict` for `param_distributions` and allow use of `OptunaSearchCV` with `cross_val_predict`)

### DIFF
--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -715,8 +715,8 @@ class OptunaSearchCV(BaseEstimator):
     ) -> None:
         _imports.check()
 
-        if not isinstance(param_distributions, dict):
-            raise TypeError("param_distributions must be a dictionary.")
+        if not isinstance(param_distributions, Mapping):
+            raise TypeError("param_distributions must be a mapping.")
 
         # Rejecting deprecated distributions as they may cause cryptic error
         # when cloning OptunaSearchCV instance.
@@ -736,7 +736,11 @@ class OptunaSearchCV(BaseEstimator):
         self.max_iter = max_iter
         self.n_trials = n_trials
         self.n_jobs = n_jobs if n_jobs else 1
-        self.param_distributions = param_distributions
+        self.param_distributions = (
+            param_distributions
+            if isinstance(param_distributions, dict)
+            else dict(param_distributions)
+        )
         self.random_state = random_state
         self.refit = refit
         self.return_train_score = return_train_score

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -638,19 +638,6 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.study_.user_attrs
 
-    def decision_function(
-        self, X, *args, **kwargs
-    ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
-        """Call ``decision_function`` on the best estimator.
-
-        This is available only if the underlying estimator supports
-        ``decision_function`` and ``refit`` is set to :obj:`True`.
-        """
-
-        self._check_is_fitted()
-
-        return self.best_estimator_.decision_function(X, *args, **kwargs)
-
     @property
     def inverse_transform(self) -> Callable[..., TwoDimArrayLikeType]:
         """Call ``inverse_transform`` on the best estimator.
@@ -662,35 +649,6 @@ class OptunaSearchCV(BaseEstimator):
         self._check_is_fitted()
 
         return self.best_estimator_.inverse_transform
-
-    def predict(
-        self, X, *args, **kwargs
-    ) -> Union[OneDimArrayLikeType | TwoDimArrayLikeType]:
-        self._check_is_fitted()
-
-        return self.best_estimator_.predict(X, *args, **kwargs)
-
-    def predict_log_proba(self, X, *args, **kwargs) -> TwoDimArrayLikeType:
-        """Call ``predict_log_proba`` on the best estimator.
-
-        This is available only if the underlying estimator supports
-        ``predict_log_proba`` and ``refit`` is set to :obj:`True`.
-        """
-
-        self._check_is_fitted()
-
-        return self.best_estimator_.predict_log_proba(X, *args, **kwargs)
-
-    def predict_proba(self, X, *args, **kwargs) -> TwoDimArrayLikeType:
-        """Call ``predict_proba`` on the best estimator.
-
-        This is available only if the underlying estimator supports
-        ``predict_proba`` and ``refit`` is set to :obj:`True`.
-        """
-
-        self._check_is_fitted()
-
-        return self.best_estimator_.predict_proba(X, *args, **kwargs)
 
     @property
     def score_samples(self) -> Callable[..., OneDimArrayLikeType]:
@@ -858,6 +816,19 @@ class OptunaSearchCV(BaseEstimator):
 
         return self
 
+    def decision_function(
+        self, X, *args, **kwargs
+    ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
+        """Call ``decision_function`` on the best estimator.
+
+        This is available only if the underlying estimator supports
+        ``decision_function`` and ``refit`` is set to :obj:`True`.
+        """
+
+        self._check_is_fitted()
+
+        return self.best_estimator_.decision_function(X, *args, **kwargs)
+
     def fit(
         self,
         X: TwoDimArrayLikeType,
@@ -976,6 +947,40 @@ class OptunaSearchCV(BaseEstimator):
         _logger.setLevel(old_level)
 
         return self
+
+    def predict(
+        self, X, *args, **kwargs
+    ) -> Union[OneDimArrayLikeType | TwoDimArrayLikeType]:
+        """Call ``predict`` on the best estimator.
+
+        This is available only if the underlying estimator supports ``predict``
+        and ``refit`` is set to :obj:`True`.
+        """
+        self._check_is_fitted()
+
+        return self.best_estimator_.predict(X, *args, **kwargs)
+
+    def predict_log_proba(self, X, *args, **kwargs) -> TwoDimArrayLikeType:
+        """Call ``predict_log_proba`` on the best estimator.
+
+        This is available only if the underlying estimator supports
+        ``predict_log_proba`` and ``refit`` is set to :obj:`True`.
+        """
+
+        self._check_is_fitted()
+
+        return self.best_estimator_.predict_log_proba(X, *args, **kwargs)
+
+    def predict_proba(self, X, *args, **kwargs) -> TwoDimArrayLikeType:
+        """Call ``predict_proba`` on the best estimator.
+
+        This is available only if the underlying estimator supports
+        ``predict_proba`` and ``refit`` is set to :obj:`True`.
+        """
+
+        self._check_is_fitted()
+
+        return self.best_estimator_.predict_proba(X, *args, **kwargs)
 
     def score(
         self,

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -1,47 +1,34 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Iterable
-from collections.abc import Mapping
-from logging import DEBUG
-from logging import INFO
-from logging import WARNING
-from numbers import Integral
-from numbers import Number
-from time import time
-from typing import Any
-from typing import List
-from typing import Union
 import warnings
+from collections.abc import Callable, Iterable, Mapping
+from logging import DEBUG, INFO, WARNING
+from numbers import Integral, Number
+from time import time
+from typing import Any, List, Union
 
 import numpy as np
-from optuna import distributions
-from optuna import logging
-from optuna import samplers
+from optuna import TrialPruned, distributions, logging, samplers
 from optuna import study as study_module
-from optuna import TrialPruned
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.study import StudyDirection
 from optuna.terminator import report_cross_validation_scores
-from optuna.trial import FrozenTrial
-from optuna.trial import Trial
-
+from optuna.trial import FrozenTrial, Trial
 
 with try_import() as _imports:
     import pandas as pd
     import scipy as sp
-    from scipy.sparse import spmatrix
-
     import sklearn
-    from sklearn.base import BaseEstimator
-    from sklearn.base import clone
-    from sklearn.base import is_classifier
+    from scipy.sparse import spmatrix
+    from sklearn.base import BaseEstimator, clone, is_classifier
     from sklearn.metrics import check_scoring
-    from sklearn.model_selection import BaseCrossValidator
-    from sklearn.model_selection import check_cv
-    from sklearn.model_selection import cross_validate
+    from sklearn.model_selection import (
+        BaseCrossValidator,
+        check_cv,
+        cross_validate,
+    )
     from sklearn.utils import _safe_indexing as sklearn_safe_indexing
     from sklearn.utils import check_random_state
     from sklearn.utils.metaestimators import _safe_split
@@ -53,8 +40,12 @@ if not _imports.is_successful():
 
 ArrayLikeType = Union[List, np.ndarray, "pd.Series", "spmatrix"]
 OneDimArrayLikeType = Union[List[float], np.ndarray, "pd.Series"]
-TwoDimArrayLikeType = Union[List[List[float]], np.ndarray, "pd.DataFrame", "spmatrix"]
-IterableType = Union[List, "pd.DataFrame", np.ndarray, "pd.Series", "spmatrix", None]
+TwoDimArrayLikeType = Union[
+    List[List[float]], np.ndarray, "pd.DataFrame", "spmatrix"
+]
+IterableType = Union[
+    List, "pd.DataFrame", np.ndarray, "pd.Series", "spmatrix", None
+]
 IndexableType = Union[Iterable, None]
 
 _logger = logging.get_logger(__name__)
@@ -75,7 +66,9 @@ def _check_fit_params(
             fit_params_validated[key] = value
         else:
             fit_params_validated[key] = _make_indexable(value)
-            fit_params_validated[key] = _safe_indexing(fit_params_validated[key], indices)
+            fit_params_validated[key] = _safe_indexing(
+                fit_params_validated[key], indices
+            )
     return fit_params_validated
 
 
@@ -83,7 +76,9 @@ def _check_fit_params(
 # https://github.com/scikit-learn/scikit-learn/blob/ \
 # 8caa93889f85254fc3ca84caa0a24a1640eebdd1/sklearn/utils/validation.py#L131-L135
 def _is_arraylike(x: Any) -> bool:
-    return hasattr(x, "__len__") or hasattr(x, "shape") or hasattr(x, "__array__")
+    return (
+        hasattr(x, "__len__") or hasattr(x, "shape") or hasattr(x, "__array__")
+    )
 
 
 # NOTE Original implementation:
@@ -112,7 +107,9 @@ def _num_samples(x: ArrayLikeType) -> int:
     try:
         return len(x)
     except TypeError:
-        raise TypeError("Expected sequence or array-like, got %s." % type(x)) from None
+        raise TypeError(
+            "Expected sequence or array-like, got %s." % type(x)
+        ) from None
 
 
 def _safe_indexing(
@@ -251,7 +248,12 @@ class _Objective:
                 fit_time = np.array([np.nan] * n_splits)
                 score_time = np.array([np.nan] * n_splits)
                 test_score = np.array(
-                    [self.error_score if self.error_score is not None else np.nan] * n_splits
+                    [
+                        self.error_score
+                        if self.error_score is not None
+                        else np.nan
+                    ]
+                    * n_splits
                 )
 
                 scores = {
@@ -263,7 +265,11 @@ class _Objective:
         self._store_scores(trial, scores)
 
         test_scores = scores["test_score"]
-        scores_list = test_scores if isinstance(test_scores, list) else test_scores.tolist()
+        scores_list = (
+            test_scores
+            if isinstance(test_scores, list)
+            else test_scores.tolist()
+        )
         try:
             report_cross_validation_scores(trial, scores_list)
         except ValueError as e:
@@ -299,8 +305,12 @@ class _Objective:
             scores["train_score"] = np.empty(n_splits)
 
         for step in range(self.max_iter):
-            for i, (train, test) in enumerate(self.cv.split(self.X, self.y, groups=self.groups)):
-                out = self._partial_fit_and_score(estimators[i], train, test, partial_fit_params)
+            for i, (train, test) in enumerate(
+                self.cv.split(self.X, self.y, groups=self.groups)
+            ):
+                out = self._partial_fit_and_score(
+                    estimators[i], train, test, partial_fit_params
+                )
 
                 if self.return_train_score:
                     scores["train_score"][i] = out.pop(0)
@@ -316,7 +326,9 @@ class _Objective:
             if trial.should_prune():
                 self._store_scores(trial, scores)
 
-                raise TrialPruned("trial was pruned at iteration {}.".format(step))
+                raise TrialPruned(
+                    "trial was pruned at iteration {}.".format(step)
+                )
 
         return scores
 
@@ -334,7 +346,9 @@ class _Objective:
         partial_fit_params: dict[str, Any],
     ) -> list[Number]:
         X_train, y_train = _safe_split(estimator, self.X, self.y, train)
-        X_test, y_test = _safe_split(estimator, self.X, self.y, test, train_indices=train)
+        X_test, y_test = _safe_split(
+            estimator, self.X, self.y, test, train_indices=train
+        )
 
         start_time = time()
 
@@ -354,7 +368,9 @@ class _Objective:
                     train_score = self.error_score
 
             else:
-                raise ValueError("error_score must be 'raise' or numeric.") from e
+                raise ValueError(
+                    "error_score must be 'raise' or numeric."
+                ) from e
 
         else:
             fit_time = time() - start_time
@@ -375,7 +391,9 @@ class _Objective:
 
         return ret
 
-    def _store_scores(self, trial: Trial, scores: Mapping[str, OneDimArrayLikeType]) -> None:
+    def _store_scores(
+        self, trial: Trial, scores: Mapping[str, OneDimArrayLikeType]
+    ) -> None:
         for name, array in scores.items():
             if name in ["test_score", "train_score"]:
                 for i, score in enumerate(array):
@@ -586,7 +604,9 @@ class OptunaSearchCV(BaseEstimator):
     def cv_results_(self) -> dict[str, Any]:
         """A dictionary mapping a metric name to a list of Cross-Validation results of all trials."""  # NOQA: E501
 
-        cv_results_dict_in_list = [trial_.user_attrs for trial_ in self.trials_]
+        cv_results_dict_in_list = [
+            trial_.user_attrs for trial_ in self.trials_
+        ]
         if len(cv_results_dict_in_list) == 0:
             cv_results_list_in_dict = {}
         else:
@@ -618,8 +638,9 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.study_.user_attrs
 
-    @property
-    def decision_function(self) -> Callable[..., OneDimArrayLikeType | TwoDimArrayLikeType]:
+    def decision_function(
+        self, X, *args, **kwargs
+    ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``decision_function`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -628,7 +649,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.decision_function
+        return self.best_estimator_.decision_function(X, *args, **kwargs)
 
     @property
     def inverse_transform(self) -> Callable[..., TwoDimArrayLikeType]:
@@ -642,20 +663,14 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.best_estimator_.inverse_transform
 
-    @property
-    def predict(self) -> Callable[..., OneDimArrayLikeType | TwoDimArrayLikeType]:
-        """Call ``predict`` on the best estimator.
-
-        This is available only if the underlying estimator supports ``predict``
-        and ``refit`` is set to :obj:`True`.
-        """
-
+    def predict(
+        self, X, *args, **kwargs
+    ) -> Union[OneDimArrayLikeType | TwoDimArrayLikeType]:
         self._check_is_fitted()
 
-        return self.best_estimator_.predict
+        return self.best_estimator_.predict(X, *args, **kwargs)
 
-    @property
-    def predict_log_proba(self) -> Callable[..., TwoDimArrayLikeType]:
+    def predict_log_proba(self, X, *args, **kwargs) -> TwoDimArrayLikeType:
         """Call ``predict_log_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -664,10 +679,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_log_proba
+        return self.best_estimator_.predict_log_proba(X, *args, **kwargs)
 
-    @property
-    def predict_proba(self) -> Callable[..., TwoDimArrayLikeType]:
+    def predict_proba(self, X, *args, **kwargs) -> TwoDimArrayLikeType:
         """Call ``predict_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -676,7 +690,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_proba
+        return self.best_estimator_.predict_proba(X, *args, **kwargs)
 
     @property
     def score_samples(self) -> Callable[..., OneDimArrayLikeType]:
@@ -737,7 +751,8 @@ class OptunaSearchCV(BaseEstimator):
         subsample: float | int = 1.0,
         timeout: float | None = None,
         verbose: int = 0,
-        callbacks: list[Callable[[study_module.Study, FrozenTrial], None]] | None = None,
+        callbacks: list[Callable[[study_module.Study, FrozenTrial], None]]
+        | None = None,
         catch: Iterable[type[Exception]] | type[Exception] = (),
     ) -> None:
         _imports.check()
@@ -789,15 +804,22 @@ class OptunaSearchCV(BaseEstimator):
 
         for name, distribution in self.param_distributions.items():
             if not isinstance(distribution, distributions.BaseDistribution):
-                raise ValueError("Value of {} must be a optuna distribution.".format(name))
+                raise ValueError(
+                    "Value of {} must be a optuna distribution.".format(name)
+                )
 
         if self.enable_pruning and not hasattr(self.estimator, "partial_fit"):
             raise ValueError("estimator must support partial_fit.")
 
         if self.max_iter <= 0:
-            raise ValueError("max_iter must be > 0, got {}.".format(self.max_iter))
+            raise ValueError(
+                "max_iter must be > 0, got {}.".format(self.max_iter)
+            )
 
-        if self.study is not None and self.study.direction != StudyDirection.MAXIMIZE:
+        if (
+            self.study is not None
+            and self.study.direction != StudyDirection.MAXIMIZE
+        ):
             raise ValueError("direction of study must be 'maximize'.")
 
     def _more_tags(self) -> dict[str, bool]:
@@ -818,7 +840,9 @@ class OptunaSearchCV(BaseEstimator):
         except ValueError as e:
             _logger.exception(e)
 
-        _logger.info("Refitting the estimator using {} samples...".format(n_samples))
+        _logger.info(
+            "Refitting the estimator using {} samples...".format(n_samples)
+        )
 
         start_time = time()
 
@@ -826,7 +850,11 @@ class OptunaSearchCV(BaseEstimator):
 
         self.refit_time_ = time() - start_time
 
-        _logger.info("Finished refitting! (elapsed time: {:.3f} sec.)".format(self.refit_time_))
+        _logger.info(
+            "Finished refitting! (elapsed time: {:.3f} sec.)".format(
+                self.refit_time_
+            )
+        )
 
         return self
 
@@ -889,7 +917,9 @@ class OptunaSearchCV(BaseEstimator):
         fit_params_res = fit_params
 
         if fit_params_res is not None:
-            fit_params_res = _check_fit_params(X, fit_params, self.sample_indices_)
+            fit_params_res = _check_fit_params(
+                X, fit_params, self.sample_indices_
+            )
 
         classifier = is_classifier(self.estimator)
         cv = check_cv(self.cv, y_res, classifier=classifier)
@@ -901,7 +931,9 @@ class OptunaSearchCV(BaseEstimator):
             seed = random_state.randint(0, np.iinfo("int32").max)
             sampler = samplers.TPESampler(seed=seed)
 
-            self.study_ = study_module.create_study(direction="maximize", sampler=sampler)
+            self.study_ = study_module.create_study(
+                direction="maximize", sampler=sampler
+            )
 
         else:
             self.study_ = self.study
@@ -922,8 +954,9 @@ class OptunaSearchCV(BaseEstimator):
         )
 
         _logger.info(
-            "Searching the best hyperparameters using {} "
-            "samples...".format(_num_samples(self.sample_indices_))
+            "Searching the best hyperparameters using {} " "samples...".format(
+                _num_samples(self.sample_indices_)
+            )
         )
 
         self.study_.optimize(

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -1,47 +1,30 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Iterable
-from collections.abc import Mapping
-from logging import DEBUG
-from logging import INFO
-from logging import WARNING
-from numbers import Integral
-from numbers import Number
-from time import time
-from typing import Any
-from typing import List
-from typing import Union
 import warnings
+from collections.abc import Callable, Iterable, Mapping
+from logging import DEBUG, INFO, WARNING
+from numbers import Integral, Number
+from time import time
+from typing import Any, List, Union
 
 import numpy as np
-from optuna import distributions
-from optuna import logging
-from optuna import samplers
+from optuna import TrialPruned, distributions, logging, samplers
 from optuna import study as study_module
-from optuna import TrialPruned
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.study import StudyDirection
 from optuna.terminator import report_cross_validation_scores
-from optuna.trial import FrozenTrial
-from optuna.trial import Trial
-
+from optuna.trial import FrozenTrial, Trial
 
 with try_import() as _imports:
     import pandas as pd
     import scipy as sp
-    from scipy.sparse import spmatrix
-
     import sklearn
-    from sklearn.base import BaseEstimator
-    from sklearn.base import clone
-    from sklearn.base import is_classifier
+    from scipy.sparse import spmatrix
+    from sklearn.base import BaseEstimator, clone, is_classifier
     from sklearn.metrics import check_scoring
-    from sklearn.model_selection import BaseCrossValidator
-    from sklearn.model_selection import check_cv
-    from sklearn.model_selection import cross_validate
+    from sklearn.model_selection import BaseCrossValidator, check_cv, cross_validate
     from sklearn.utils import _safe_indexing as sklearn_safe_indexing
     from sklearn.utils import check_random_state
     from sklearn.utils.metaestimators import _safe_split
@@ -789,9 +772,7 @@ class OptunaSearchCV(BaseEstimator):
 
         return self
 
-    def decision_function(
-        self, X: Any, *args: Any, **kwargs: Any
-    ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
+    def decision_function(self, X: Any) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``decision_function`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -800,7 +781,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.decision_function(X, *args, **kwargs)
+        return self.best_estimator_.decision_function(X)
 
     def fit(
         self,
@@ -916,9 +897,7 @@ class OptunaSearchCV(BaseEstimator):
 
         return self
 
-    def predict(
-        self, X: Any, *args: Any, **kwargs: Any
-    ) -> Union[OneDimArrayLikeType | TwoDimArrayLikeType]:
+    def predict(self, X: Any) -> Union[OneDimArrayLikeType | TwoDimArrayLikeType]:
         """Call ``predict`` on the best estimator.
 
         This is available only if the underlying estimator supports ``predict``
@@ -926,9 +905,9 @@ class OptunaSearchCV(BaseEstimator):
         """
         self._check_is_fitted()
 
-        return self.best_estimator_.predict(X, *args, **kwargs)
+        return self.best_estimator_.predict(X)
 
-    def predict_log_proba(self, X: Any, *args: Any, **kwargs: Any) -> TwoDimArrayLikeType:
+    def predict_log_proba(self, X: Any) -> TwoDimArrayLikeType:
         """Call ``predict_log_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -937,9 +916,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_log_proba(X, *args, **kwargs)
+        return self.best_estimator_.predict_log_proba(X)
 
-    def predict_proba(self, X: Any, *args: Any, **kwargs: Any) -> TwoDimArrayLikeType:
+    def predict_proba(self, X: Any) -> TwoDimArrayLikeType:
         """Call ``predict_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -948,7 +927,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_proba(X, *args, **kwargs)
+        return self.best_estimator_.predict_proba(X)
 
     def score(
         self,

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -1,30 +1,47 @@
 from __future__ import annotations
 
-import warnings
-from collections.abc import Callable, Iterable, Mapping
-from logging import DEBUG, INFO, WARNING
-from numbers import Integral, Number
+from collections.abc import Callable
+from collections.abc import Iterable
+from collections.abc import Mapping
+from logging import DEBUG
+from logging import INFO
+from logging import WARNING
+from numbers import Integral
+from numbers import Number
 from time import time
-from typing import Any, List, Union
+from typing import Any
+from typing import List
+from typing import Union
+import warnings
 
 import numpy as np
-from optuna import TrialPruned, distributions, logging, samplers
+from optuna import distributions
+from optuna import logging
+from optuna import samplers
 from optuna import study as study_module
+from optuna import TrialPruned
 from optuna._experimental import experimental_class
 from optuna._imports import try_import
 from optuna.distributions import _convert_old_distribution_to_new_distribution
 from optuna.study import StudyDirection
 from optuna.terminator import report_cross_validation_scores
-from optuna.trial import FrozenTrial, Trial
+from optuna.trial import FrozenTrial
+from optuna.trial import Trial
+
 
 with try_import() as _imports:
     import pandas as pd
     import scipy as sp
-    import sklearn
     from scipy.sparse import spmatrix
-    from sklearn.base import BaseEstimator, clone, is_classifier
+
+    import sklearn
+    from sklearn.base import BaseEstimator
+    from sklearn.base import clone
+    from sklearn.base import is_classifier
     from sklearn.metrics import check_scoring
-    from sklearn.model_selection import BaseCrossValidator, check_cv, cross_validate
+    from sklearn.model_selection import BaseCrossValidator
+    from sklearn.model_selection import check_cv
+    from sklearn.model_selection import cross_validate
     from sklearn.utils import _safe_indexing as sklearn_safe_indexing
     from sklearn.utils import check_random_state
     from sklearn.utils.metaestimators import _safe_split


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

I have two motivations.

1. Accept `Mapping` in addition to `dict` for `param_distributions`.
2. Allow use of `OptunaSearchCV` with `cross_val_predict`.

## Description of the changes
<!-- Describe the changes in this PR. -->

### 1. Accept `Mapping` in addition to `dict` for `param_distributions`.

Changed the accepted type from `dict` to `Mapping`.

`MappingProxyType` and other types cannot be made to pickle, which causes an error during parallelization, so the specification has been changed to change to `dict` after accepting the `Mapping` type.


### 2. Allow use of `OptunaSearchCV` with `cross_val_predict`.

In scikit-learn's `HasMethods`, `predict` (and related methods) get error because of 'property', so define them as method.