### PR TITLE
Allow use of `OptunaSearchCV` with `cross_val_predict`.

### DIFF
--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -622,7 +622,7 @@ class OptunaSearchCV(BaseEstimator):
         return self.study_.user_attrs
 
     def decision_function(
-        self, X: TwoDimArrayLikeType
+        self, X: TwoDimArrayLikeType, **params: Any
     ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``decision_function`` on the best estimator.
 
@@ -632,7 +632,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.decision_function(X)
+        return self.best_estimator_.decision_function(X, **params)
 
     @property
     def inverse_transform(self) -> Callable[..., TwoDimArrayLikeType]:
@@ -646,7 +646,9 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.best_estimator_.inverse_transform
 
-    def predict(self, X: TwoDimArrayLikeType) -> OneDimArrayLikeType | TwoDimArrayLikeType:
+    def predict(
+        self, X: TwoDimArrayLikeType, **params: Any
+    ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``predict`` on the best estimator.
 
         This is available only if the underlying estimator supports ``predict``
@@ -655,9 +657,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict(X)
+        return self.best_estimator_.predict(X, **params)
 
-    def predict_log_proba(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
+    def predict_log_proba(self, X: TwoDimArrayLikeType, **params: Any) -> TwoDimArrayLikeType:
         """Call ``predict_log_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -666,9 +668,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_log_proba(X)
+        return self.best_estimator_.predict_log_proba(X, **params)
 
-    def predict_proba(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
+    def predict_proba(self, X: TwoDimArrayLikeType, **params: Any) -> TwoDimArrayLikeType:
         """Call ``predict_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -677,7 +679,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_proba(X)
+        return self.best_estimator_.predict_proba(X, **params)
 
     @property
     def score_samples(self) -> Callable[..., OneDimArrayLikeType]:

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -622,7 +622,7 @@ class OptunaSearchCV(BaseEstimator):
         return self.study_.user_attrs
 
     def decision_function(
-        self, X: TwoDimArrayLikeType, **params: Any
+        self, X: TwoDimArrayLikeType, **kwargs: Any
     ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``decision_function`` on the best estimator.
 
@@ -632,7 +632,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.decision_function(X, **params)
+        return self.best_estimator_.decision_function(X, **kwargs)
 
     @property
     def inverse_transform(self) -> Callable[..., TwoDimArrayLikeType]:
@@ -647,7 +647,7 @@ class OptunaSearchCV(BaseEstimator):
         return self.best_estimator_.inverse_transform
 
     def predict(
-        self, X: TwoDimArrayLikeType, **params: Any
+        self, X: TwoDimArrayLikeType, **kwargs: Any
     ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``predict`` on the best estimator.
 
@@ -657,9 +657,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict(X, **params)
+        return self.best_estimator_.predict(X, **kwargs)
 
-    def predict_log_proba(self, X: TwoDimArrayLikeType, **params: Any) -> TwoDimArrayLikeType:
+    def predict_log_proba(self, X: TwoDimArrayLikeType, **kwargs: Any) -> TwoDimArrayLikeType:
         """Call ``predict_log_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -668,9 +668,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_log_proba(X, **params)
+        return self.best_estimator_.predict_log_proba(X, **kwargs)
 
-    def predict_proba(self, X: TwoDimArrayLikeType, **params: Any) -> TwoDimArrayLikeType:
+    def predict_proba(self, X: TwoDimArrayLikeType, **kwargs: Any) -> TwoDimArrayLikeType:
         """Call ``predict_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -679,7 +679,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_proba(X, **params)
+        return self.best_estimator_.predict_proba(X, **kwargs)
 
     @property
     def score_samples(self) -> Callable[..., OneDimArrayLikeType]:

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -621,8 +621,9 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.study_.user_attrs
 
-    @property
-    def decision_function(self) -> Callable[..., OneDimArrayLikeType | TwoDimArrayLikeType]:
+    def decision_function(
+        self, X: TwoDimArrayLikeType
+    ) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``decision_function`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -631,7 +632,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.decision_function
+        return self.best_estimator_.decision_function(X)
 
     @property
     def inverse_transform(self) -> Callable[..., TwoDimArrayLikeType]:
@@ -645,8 +646,7 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.best_estimator_.inverse_transform
 
-    @property
-    def predict(self) -> Callable[..., OneDimArrayLikeType | TwoDimArrayLikeType]:
+    def predict(self, X: TwoDimArrayLikeType) -> OneDimArrayLikeType | TwoDimArrayLikeType:
         """Call ``predict`` on the best estimator.
 
         This is available only if the underlying estimator supports ``predict``
@@ -655,10 +655,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict
+        return self.best_estimator_.predict(X)
 
-    @property
-    def predict_log_proba(self) -> Callable[..., TwoDimArrayLikeType]:
+    def predict_log_proba(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
         """Call ``predict_log_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -667,10 +666,9 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_log_proba
+        return self.best_estimator_.predict_log_proba(X)
 
-    @property
-    def predict_proba(self) -> Callable[..., TwoDimArrayLikeType]:
+    def predict_proba(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
         """Call ``predict_proba`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -679,7 +677,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.predict_proba
+        return self.best_estimator_.predict_proba(X)
 
     @property
     def score_samples(self) -> Callable[..., OneDimArrayLikeType]:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

#173  explained.

## Description of the changes
<!-- Describe the changes in this PR. -->

Re-define some property (`predict` and related one) as method.

### Environment
- Optuna version:3.5.0
- Optuna Integration version:3.5.0
- Python version:3.11.6
- OS:macOS-14.7-arm64-arm-64bit
- scikit-learn version: 1.4.0

I've tested locally as follows;

```python
import optuna
from sklearn.cross_decomposition import PLSRegression
from sklearn.datasets import make_regression
from sklearn.model_selection import cross_val_predict

X, y = make_regression(n_samples=100, n_features=10, bias=1, random_state=334)

ocv = optuna.integration.OptunaSearchCV(
    PLSRegression(),
    param_distributions=dict(n_components=optuna.distributions.IntDistribution(1, 10)),
    cv=5,
)
y_oof = cross_val_predict(ocv, X, y, cv=5)
```

and,

```python
import optuna
from sklearn.tree import DecisionTreeClassifier
from sklearn.datasets import make_classification
from sklearn.model_selection import cross_val_predict

X, y = make_classification(n_samples=100, n_features=10, random_state=334)

ocv = optuna.integration.OptunaSearchCV(
    DecisionTreeClassifier(random_state=334),
    param_distributions=dict(max_depth=optuna.distributions.IntDistribution(1, 10)),
    cv=5,
    random_state=334,
)
y_oof = cross_val_predict(ocv, X, y, cv=5, method="predict_proba")
```