### PR TITLE
Fix a GitHub action workflow for publishing to PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -51,17 +51,21 @@ jobs:
       run: |
         python -m build
 
-    - name: Verify the distributions
-      run: twine check dist/*
-
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.
       if: (github.event_name == 'schedule') || (github.event_name == 'release')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        # Temporary workaround to avoid the Twine's bug for attestations support.
+        # See https://github.com/pypa/gh-action-pypi-publish/issues/283
+        attestations: false
 
     - name: Publish distribution to PyPI
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # Temporary workaround to avoid the Twine's bug for attestations support.
+        # See https://github.com/pypa/gh-action-pypi-publish/issues/283
+        attestations: false


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Refs https://github.com/optuna/optuna/pull/5759

## Description of the changes
<!-- Describe the changes in this PR. -->
This PR bypasses a twine's bug by turning off release attestations. Please see the below issue and a PR for details.

* https://github.com/pypa/gh-action-pypi-publish/issues/283
* https://github.com/langchain-ai/langchain/pull/27765