### PR TITLE
Fix CI

### DIFF
--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -494,8 +494,7 @@ class _LightGBMBaseTuner(_BaseTuner):
 
     def tune_feature_fraction(self, n_trials: int = 7) -> None:
         param_name = "feature_fraction"
-        param_values = [0.4 + 0.6 * i / (n_trials - 1) for i in range(n_trials)]
-
+        param_values = cast(list, np.linspace(0.4, 1.0, n_trials).tolist())
         sampler = optuna.samplers.GridSampler({param_name: param_values}, seed=self._optuna_seed)
         self._tune_params([param_name], len(param_values), sampler, "feature_fraction")
 

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -648,7 +648,7 @@ class OptunaSearchCV(BaseEstimator):
 
         This is available only if the underlying estimator supports
         ``inverse_transform`` and ``refit`` is set to :obj:`True`.
-        Note that we support the argument detailed in
+        Please check the following to know more about ``inverse_transform``:
         https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer.inverse_transform
         """
 
@@ -716,7 +716,7 @@ class OptunaSearchCV(BaseEstimator):
 
         This is available only if the underlying estimator supports
         ``transform`` and ``refit`` is set to :obj:`True`.
-        Note that we support the argument detailed in
+        Please check the following to know more about ``transform``:
         https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer.transform
         """
 

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -641,7 +641,9 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.best_estimator_.decision_function(X, **kwargs)
 
-    def inverse_transform(self, X: TwoDimArrayLikeType, **kwargs: Any) -> TwoDimArrayLikeType:
+    def inverse_transform(
+        self, X: TwoDimArrayLikeType, *args: Any, **kwargs: Any
+    ) -> TwoDimArrayLikeType:
         """Call ``inverse_transform`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -652,7 +654,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.inverse_transform(X, **kwargs)
+        return self.best_estimator_.inverse_transform(X, *args, **kwargs)
 
     def predict(
         self, X: TwoDimArrayLikeType, **kwargs: Any
@@ -709,7 +711,7 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.study_.set_user_attr
 
-    def transform(self, X: TwoDimArrayLikeType, **kwargs: Any) -> TwoDimArrayLikeType:
+    def transform(self, X: TwoDimArrayLikeType, *args: Any, **kwargs: Any) -> TwoDimArrayLikeType:
         """Call ``transform`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -720,7 +722,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.transform(X, **kwargs)
+        return self.best_estimator_.transform(X, *args, **kwargs)
 
     @property
     def trials_dataframe(self) -> Callable[..., "pd.DataFrame"]:

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -641,7 +641,7 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.best_estimator_.decision_function(X, **kwargs)
 
-    def inverse_transform(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
+    def inverse_transform(self, X: TwoDimArrayLikeType, **kwargs: Any) -> TwoDimArrayLikeType:
         """Call ``inverse_transform`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -652,7 +652,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.inverse_transform(X)
+        return self.best_estimator_.inverse_transform(X, **kwargs)
 
     def predict(
         self, X: TwoDimArrayLikeType, **kwargs: Any
@@ -709,7 +709,7 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.study_.set_user_attr
 
-    def transform(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
+    def transform(self, X: TwoDimArrayLikeType, **kwargs: Any) -> TwoDimArrayLikeType:
         """Call ``transform`` on the best estimator.
 
         This is available only if the underlying estimator supports
@@ -720,7 +720,7 @@ class OptunaSearchCV(BaseEstimator):
 
         self._check_is_fitted()
 
-        return self.best_estimator_.transform(X)
+        return self.best_estimator_.transform(X, **kwargs)
 
     @property
     def trials_dataframe(self) -> Callable[..., "pd.DataFrame"]:

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -641,17 +641,18 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.best_estimator_.decision_function(X, **kwargs)
 
-    @property
-    def inverse_transform(self) -> Callable[..., TwoDimArrayLikeType]:
+    def inverse_transform(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
         """Call ``inverse_transform`` on the best estimator.
 
         This is available only if the underlying estimator supports
         ``inverse_transform`` and ``refit`` is set to :obj:`True`.
+        Note that we support the argument detailed in
+        https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer.inverse_transform
         """
 
         self._check_is_fitted()
 
-        return self.best_estimator_.inverse_transform
+        return self.best_estimator_.inverse_transform(X)
 
     def predict(
         self, X: TwoDimArrayLikeType, **kwargs: Any
@@ -708,17 +709,18 @@ class OptunaSearchCV(BaseEstimator):
 
         return self.study_.set_user_attr
 
-    @property
-    def transform(self) -> Callable[..., TwoDimArrayLikeType]:
+    def transform(self, X: TwoDimArrayLikeType) -> TwoDimArrayLikeType:
         """Call ``transform`` on the best estimator.
 
         This is available only if the underlying estimator supports
         ``transform`` and ``refit`` is set to :obj:`True`.
+        Note that we support the argument detailed in
+        https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer.transform
         """
 
         self._check_is_fitted()
 
-        return self.best_estimator_.transform
+        return self.best_estimator_.transform(X)
 
     @property
     def trials_dataframe(self) -> Callable[..., "pd.DataFrame"]:

--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -263,7 +263,7 @@ class _Objective:
         self._store_scores(trial, scores)
 
         test_scores = scores["test_score"]
-        scores_list = test_scores if isinstance(test_scores, list) else [v for v in test_scores]
+        scores_list = test_scores if isinstance(test_scores, list) else list(test_scores.tolist())
         try:
             report_cross_validation_scores(trial, scores_list)
         except ValueError as e:
@@ -303,12 +303,17 @@ class _Objective:
 
         for step in range(self.max_iter):
             for i, (train, test) in enumerate(self.cv.split(self.X, self.y, groups=self.groups)):
-                _out = self._partial_fit_and_score(estimators[i], train, test, partial_fit_params)
-                out = np.asarray(_out, dtype=np.float64)
+                out = list(
+                    np.asarray(
+                        self._partial_fit_and_score(
+                            estimators[i], train, test, partial_fit_params
+                        ),
+                        dtype=float,
+                    ).tolist()
+                )
 
                 if self.return_train_score:
-                    scores["train_score"][i] = out[0]
-                    out = out[1:]
+                    scores["train_score"][i] = out.pop(0)
 
                 scores["test_score"][i] = out[0]
                 scores["fit_time"][i] += out[1]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR fixes the CI.

In principle, the errors in CI happen because of the following:

```python
class C:
  @property
  def f(self):
    self.f()

hasattr(C(), "f")

>>> RecursionError: maximum recursion depth exceeded
```

From scikit-learn v1.6.0, it seems that `check_is_fitted` calls `hasattr(estimator, "transform")`, which triggers the getter of the `OptunaSearchCV.transform` property.
This, in turn, calls `self._check_is_fitted()` in the property and we yield the infinite loop of `check_is_fitted`.

## Description of the changes
<!-- Describe the changes in this PR. -->

To avoid the problem above, I made `inverse_transform` and `transform` the methods of the `OptunaSearchCV` object.
Note that I confirmed the possible arguments of these methods [here](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html)