### PR TITLE
Set repository url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,9 @@ xgboost = [
     "xgboost",
 ]
 
+[project.urls]
+repository = "https://github.com/optuna/optuna-integration"
+
 [tool.setuptools.packages.find]
 # where = ["."]
 include = ["optuna_integration*"]


### PR DESCRIPTION
## Motivation
Hi.

I just noticed renovate bot does not paste the release note to the PR for optuna-integration, while it does to one for optuna. I suspect that the reason is the missing repository URL in pyproject.toml.

## Description of the changes
Added `project.urls.repository` field of pyproject.toml.
