### PR TITLE
Add flake8 in ci

### DIFF
--- a/.github/workflows/checks_template.yml
+++ b/.github/workflows/checks_template.yml
@@ -74,6 +74,15 @@ jobs:
             blackdoc tests/${{ inputs.integration_name }} --check --diff
           fi
 
+      - name: Flake8
+        run: |
+          if [ -e optuna_integration/${{ inputs.integration_name }} ]; then
+            flake8 optuna_integration/${{ inputs.integration_name }}
+          fi
+          if [ -e tests/${{ inputs.integration_name }} ]; then
+            flake8 tests/${{ inputs.integration_name }}
+          fi
+
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -31,7 +33,7 @@ with try_import() as _imports:
     from botorch.acquisition.multi_objective import monte_carlo
     from botorch.acquisition.multi_objective.analytic import ExpectedHypervolumeImprovement
     from botorch.acquisition.multi_objective.objective import (
-        FeasibilityWeightedMCMultiOutputObjective,  # noqa: H301
+        FeasibilityWeightedMCMultiOutputObjective,
     )
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
@@ -76,7 +78,7 @@ with try_import() as _imports_logei:
 
 with try_import() as _imports_qhvkg:
     from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (
-        qHypervolumeKnowledgeGradient,  # noqa: H301
+        qHypervolumeKnowledgeGradient,
     )
 
 

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -31,7 +31,7 @@ with try_import() as _imports:
     from botorch.acquisition.multi_objective import monte_carlo
     from botorch.acquisition.multi_objective.analytic import ExpectedHypervolumeImprovement
     from botorch.acquisition.multi_objective.objective import (
-        FeasibilityWeightedMCMultiOutputObjective,
+        FeasibilityWeightedMCMultiOutputObjective,  # noqa: H301
     )
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
@@ -76,7 +76,7 @@ with try_import() as _imports_logei:
 
 with try_import() as _imports_qhvkg:
     from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (
-        qHypervolumeKnowledgeGradient,
+        qHypervolumeKnowledgeGradient,  # noqa: H301
     )
 
 

--- a/optuna_integration/comet/comet.py
+++ b/optuna_integration/comet/comet.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 from __future__ import annotations
 
 from collections.abc import Callable


### PR DESCRIPTION
## Motivation
Add flake8 in CI, which is accidently deleted in [#98 ](https://github.com/optuna/optuna-integration/pull/98)

## Description of the changes
- Add flake8 in `.github/workflows/check_template.yml`
- Make it to Ignore errors in some files
- The issue is filed here: [Fix Flake8 Errors in CI #202](https://github.com/optuna/optuna-integration/issues/202)