### PR TITLE
[hotfix] Add the version constraint on LightGBM

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -133,6 +133,8 @@ jobs:
     uses: ./.github/workflows/checks_template.yml
     with:
       integration_name: 'lightgbm'
+      # TODO: Remove the version constraint once https://github.com/optuna/optuna-integration/issues/204 is resolved.
+      extra_cmds: pip install torch "lightgbm<=4.5.0"
       deprecated: false
 
   mlflow:


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Refs https://github.com/optuna/optuna-integration/issues/204 and https://github.com/optuna/optuna-examples/pull/302

## Description of the changes
<!-- Describe the changes in this PR. -->
LightGBM 4.6.0 was released two days ago, causing the workflow to fail. This PR adds a version constraint on LightGBM as a hotfix.