### PR TITLE
[fix] lgbm 4.6.0 compatibility

### DIFF
--- a/optuna_integration/_lightgbm_tuner/_train.py
+++ b/optuna_integration/_lightgbm_tuner/_train.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
-from typing import Optional
 
 from optuna._imports import try_import
 from optuna.study import Study

--- a/optuna_integration/_lightgbm_tuner/_train.py
+++ b/optuna_integration/_lightgbm_tuner/_train.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+from typing import Optional
 
 from optuna._imports import try_import
 from optuna.study import Study
@@ -22,8 +23,8 @@ def train(
     valid_sets: list["lgb.Dataset"] | tuple["lgb.Dataset", ...] | "lgb.Dataset" | None = None,
     valid_names: Any | None = None,
     feval: Callable[..., Any] | None = None,
-    feature_name: str = "auto",
-    categorical_feature: str = "auto",
+    feature_name: str | None = None,
+    categorical_feature: str | None = None,
     keep_training_booster: bool = False,
     callbacks: list[Callable[..., Any]] | None = None,
     time_budget: int | None = None,

--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -384,9 +384,7 @@ class _LightGBMBaseTuner(_BaseTuner):
             show_progress_bar=show_progress_bar,
         )
 
-        deprecated_arg_warning = (
-            "{deprecated_arg} is deprecated in lightgbm 4.6.0 and will be removed in the future."
-        )
+        deprecated_arg_warning = "Support for lgb.cv with argument {deprecated_arg} was removed from lightgbm 4.6.0 and will not be supported by optuna in the future."
         if feature_name:
             warnings.warn(deprecated_arg_warning.format(deprecated_arg="feature_name"))
             kwargs["feature_name"] = feature_name

--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -385,8 +385,8 @@ class _LightGBMBaseTuner(_BaseTuner):
         )
 
         deprecated_arg_warning = (
-            "Support for lgb.cv with argument {deprecated_arg} was removed from lightgbm 4.6.0 "
-            "and will not be supported by optuna in the future."
+            "Support for lgb.train and lgb.cv with argument {deprecated_arg} was removed "
+            "from lightgbm 4.6.0 and will not be supported by optuna in the future."
         )
         if feature_name:
             warnings.warn(deprecated_arg_warning.format(deprecated_arg="feature_name"))
@@ -678,6 +678,12 @@ class LightGBMTuner(_LightGBMBaseTuner):
         For ``params``, please check `the official documentation for LightGBM
         <https://lightgbm.readthedocs.io/en/latest/Parameters.html>`_.
 
+    .. warning::
+        Arguments ``feature_name`` and ``categorical_feature`` were deprecated in v4.2.2 and
+        will be removed in the future. The removal of these arguments is currently scheduled
+        for v6.0.0, but this schedule is subject to change.
+        See https://github.com/optuna/optuna-integration/releases/tag/v4.2.2.
+
     The arguments that only :class:`~optuna_integration.lightgbm.LightGBMTuner` has are
     listed below:
 
@@ -848,6 +854,12 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
         ``metrics``, ``init_model`` and ``eval_train_metric``.
         For ``params``, please check `the official documentation for LightGBM
         <https://lightgbm.readthedocs.io/en/latest/Parameters.html>`_.
+
+    .. warning::
+        Arguments ``feature_name`` and ``categorical_feature`` were deprecated in v4.2.2 and
+        will be removed in the future. The removal of these arguments is currently scheduled
+        for v6.0.0, but this schedule is subject to change.
+        See https://github.com/optuna/optuna-integration/releases/tag/v4.2.2.
 
     The arguments that only :class:`~optuna_integration.lightgbm.LightGBMTunerCV` has are
     listed below:

--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -384,7 +384,10 @@ class _LightGBMBaseTuner(_BaseTuner):
             show_progress_bar=show_progress_bar,
         )
 
-        deprecated_arg_warning = "Support for lgb.cv with argument {deprecated_arg} was removed from lightgbm 4.6.0 and will not be supported by optuna in the future."
+        deprecated_arg_warning = (
+            "Support for lgb.cv with argument {deprecated_arg} was removed from lightgbm 4.6.0 "
+            "and will not be supported by optuna in the future."
+        )
         if feature_name:
             warnings.warn(deprecated_arg_warning.format(deprecated_arg="feature_name"))
             kwargs["feature_name"] = feature_name

--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -357,8 +357,8 @@ class _LightGBMBaseTuner(_BaseTuner):
         callbacks: list[Callable[..., Any]] | None = None,
         num_boost_round: int = 1000,
         feval: Callable[..., Any] | None = None,
-        feature_name: str = "auto",
-        categorical_feature: str = "auto",
+        feature_name: str | None = None,
+        categorical_feature: str | None = None,
         time_budget: int | None = None,
         sample_size: int | None = None,
         study: optuna.study.Study | None = None,
@@ -378,13 +378,22 @@ class _LightGBMBaseTuner(_BaseTuner):
         kwargs: dict[str, Any] = dict(
             num_boost_round=num_boost_round,
             feval=feval,
-            feature_name=feature_name,
-            categorical_feature=categorical_feature,
             callbacks=callbacks,
             time_budget=time_budget,
             sample_size=sample_size,
             show_progress_bar=show_progress_bar,
         )
+
+        deprecated_arg_warning = (
+            "{deprecated_arg} is deprecated in lightgbm 4.6.0 and will be removed in the future."
+        )
+        if feature_name:
+            warnings.warn(deprecated_arg_warning.format(deprecated_arg="feature_name"))
+            kwargs["feature_name"] = feature_name
+        if categorical_feature:
+            warnings.warn(deprecated_arg_warning.format(deprecated_arg="categorical_feature"))
+            kwargs["categorical_feature"] = categorical_feature
+
         self._parse_args(*args, **kwargs)
         self._start_time: float | None = None
         self._optuna_callbacks = optuna_callbacks
@@ -726,8 +735,8 @@ class LightGBMTuner(_LightGBMBaseTuner):
         valid_sets: list["lgb.Dataset"] | tuple["lgb.Dataset", ...] | "lgb.Dataset" | None = None,
         valid_names: Any | None = None,
         feval: Callable[..., Any] | None = None,
-        feature_name: str = "auto",
-        categorical_feature: str = "auto",
+        feature_name: str | None = None,
+        categorical_feature: str | None = None,
         keep_training_booster: bool = False,
         callbacks: list[Callable[..., Any]] | None = None,
         time_budget: int | None = None,
@@ -909,8 +918,8 @@ class LightGBMTunerCV(_LightGBMBaseTuner):
         stratified: bool = True,
         shuffle: bool = True,
         feval: Callable[..., Any] | None = None,
-        feature_name: str = "auto",
-        categorical_feature: str = "auto",
+        feature_name: str | None = None,
+        categorical_feature: str | None = None,
         fpreproc: Callable[..., Any] | None = None,
         seed: int = 0,
         callbacks: list[Callable[..., Any]] | None = None,

--- a/optuna_integration/lightgbm/lightgbm.py
+++ b/optuna_integration/lightgbm/lightgbm.py
@@ -77,7 +77,7 @@ class LightGBMPruningCallback:
 
         # The structure of each member of `evaluation_result_list` as of LightGBM v4.6.0.
         # [
-        #     (<dataset_name>, <metric_name>, mean(<values>), <is_higher_better>, std_dev(<values>))
+        #     (<dataset_name>, <metric_name>, avg(<values>), <is_higher_better>, std_dev(<values>))
         # ]
         for evaluation_result in evaluation_result_list:
             valid_name, metric, current_score, is_higher_better = evaluation_result[:4]

--- a/optuna_integration/lightgbm/lightgbm.py
+++ b/optuna_integration/lightgbm/lightgbm.py
@@ -75,6 +75,10 @@ class LightGBMPruningCallback:
         if evaluation_result_list is None:
             return None
 
+        # The structure of each member of `evaluation_result_list` as of LightGBM v4.6.0.
+        # [
+        #     (<dataset_name>, <metric_name>, mean(<values>), <is_higher_better>, std_dev(<values>))
+        # ]
         for evaluation_result in evaluation_result_list:
             valid_name, metric, current_score, is_higher_better = evaluation_result[:4]
             # The prefix "valid " is added to metric name since LightGBM v4.0.0.
@@ -99,12 +103,11 @@ class LightGBMPruningCallback:
                 and len(evaluation_result_list[0]) == 5
             )
             if is_cv:
-                target_valid_name = "cv_agg"
+                target_valid_name = "valid"
             else:
                 target_valid_name = self._valid_name
 
             evaluation_result = self._find_evaluation_result(target_valid_name, env)
-
             if evaluation_result is None:
                 raise ValueError(
                     'The entry associated with the validation name "{}" and the metric name "{}" '

--- a/tests/lightgbm/test_lightgbm.py
+++ b/tests/lightgbm/test_lightgbm.py
@@ -32,7 +32,7 @@ def test_lightgbm_pruning_callback_call(cv: bool) -> None:
     )
 
     if cv:
-        env = callback_env(evaluation_result_list=[("cv_agg", "binary_error", 1.0, False, 1.0)])
+        env = callback_env(evaluation_result_list=[("valid", "binary_error", 1.0, False, 1.0)])
     else:
         env = callback_env(evaluation_result_list=[("validation", "binary_error", 1.0, False)])
 


### PR DESCRIPTION
## Motivation

Makes two changes to let `optuna-integration[lightgbm]` be compatible with the latest release of lightgbm, 4.6.0.

Attempts to resolve issue [204](https://github.com/optuna/optuna-integration/pull/204) 

[Here](https://github.com/microsoft/LightGBM/compare/v4.5.0...v4.6.0#) is a link to the diff between lightgbm 4.5.0 (works with optuna-integration[lightgbm]) and 4.6.0 (does not work).

The breaking changes are in these two PRs:
- [#6706](https://github.com/microsoft/LightGBM/pull/6706). The fix for this is straightforard.
-  [#6761](https://github.com/microsoft/LightGBM/pull/6761). I'm less sure about my fix to address this change.

## Description of the changes

1. The `feature_name` and `categorical_feature` arguments to `lgb.train` and `lgb.cv` were removed in LightGBM [#6706](https://github.com/microsoft/LightGBM/pull/6706). So, makes those arguments default to `None` and only adds them to `lgbm_kwargs` in `_LightGBMBaseTuner` (and subsequent child classes) when they are explicitly provided. Adds a warning to the user that they should... not set these arguments. These should be removed in the future, but it's best to support backwards compatibility for folks still using lightgbm < 4.6.0.
2. In LightGBM [#6761](https://github.com/microsoft/LightGBM/pull/6761) the structure of `_agg_cv_result` was changed and the literal `cv_agg` was removed. Therefore, we need to stop trying to match on `cv_agg` in `LightGBMPruningCallback._find_evaluation_result` to back out the correct cross validation metric set for early stopping callbacks.
  - I am admittedly not sure my changes are the right approach to fix `LightGBMPruningCallback` here and could use help from maintainers (of this repo or LightGBM).