### PR TITLE
Fix a mypy error when using numpy>=2.2.4

### DIFF
--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -555,9 +555,12 @@ class _LightGBMBaseTuner(_BaseTuner):
     def tune_feature_fraction_stage2(self, n_trials: int = 6) -> None:
         param_name = "feature_fraction"
         best_feature_fraction = self.best_params[param_name]
-        param_values = np.linspace(
-            best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
-        ).tolist()
+        param_values: list[float] = cast(
+            list[float],
+            np.linspace(
+                best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
+            ).tolist(),
+        )
         param_values = [val for val in param_values if val >= 0.4 and val <= 1.0]
 
         sampler = optuna.samplers.GridSampler({param_name: param_values}, seed=self._optuna_seed)


### PR DESCRIPTION
## Motivation
With Numpy=2.2.4, mypy raises following errors.
https://github.com/optuna/optuna-integration/actions/runs/13935185091/job/39001498800

```
$ mypy optuna_integration/_lightgbm_tuner/
Success: no issues found in 5 source files
$ pip install -U numpy
Requirement already satisfied: numpy in ./venv/lib/python3.11/site-packages (2.1.3)
Collecting numpy
  Downloading numpy-2.2.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (62 kB)
Downloading numpy-2.2.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.4 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.4/16.4 MB 84.9 MB/s eta 0:00:00
Installing collected packages: numpy
  Attempting uninstall: numpy
    Found existing installation: numpy 2.1.3
    Uninstalling numpy-2.1.3:
      Successfully uninstalled numpy-2.1.3
Successfully installed numpy-2.2.4

[notice] A new release of pip is available: 24.3.1 -> 25.0.1
[notice] To update, run: pip install --upgrade pip
$ mypy optuna_integration/_lightgbm_tuner/
optuna_integration/_lightgbm_tuner/optimize.py:561: error: Incompatible types in assignment (expression has type "list[str]", variable has type "str")  [assignment]
optuna_integration/_lightgbm_tuner/optimize.py:561: error: Unsupported operand types for >= ("str" and "float")  [operator]
optuna_integration/_lightgbm_tuner/optimize.py:561: error: Unsupported operand types for <= ("str" and "float")  [operator]
Found 3 errors in 1 file (checked 5 source files)
```

## Description of the changes
To address the above issue, the type of the `param_values` variable is cast using `typing.cast`.