### PR TITLE
Convert storage into `InMemoryStorage` before copying to the local

### DIFF
--- a/tests/dask/test_dask.py
+++ b/tests/dask/test_dask.py
@@ -7,6 +7,7 @@ import warnings
 
 import numpy as np
 import optuna
+from optuna.storages import InMemoryStorage
 from optuna.testing.tempfile_pool import NamedTemporaryFilePool
 from optuna.trial import Trial
 import pytest
@@ -108,8 +109,7 @@ def test_get_base_storage(client: "Client", storage_specifier: str) -> None:
             warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
             dask_storage = DaskStorage(url)
         storage = dask_storage.get_base_storage()
-        expected_type = type(optuna.storages.get_storage(url))
-        assert type(storage) is expected_type
+        assert type(storage) is InMemoryStorage
 
 
 @pytest.mark.parametrize("direction", ["maximize", "minimize"])


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fixes #211 

## Description of the changes
<!-- Describe the changes in this PR. -->

When copying the storage from the cluster to local, the storage itself was serialized and transferred, but the SQLite DB file referenced by `RDBStorage` was not included. This caused issues like the one in issue #211.  
By converting the storage to `InMemoryStorage` on the cluster side before copying, the process now works correctly.
