### PR TITLE
Fix a bug of lightgbm tuner for Python 3.8 users

### DIFF
--- a/optuna_integration/_lightgbm_tuner/optimize.py
+++ b/optuna_integration/_lightgbm_tuner/optimize.py
@@ -14,6 +14,7 @@ import pickle
 import time
 from typing import Any
 from typing import cast
+from typing import List
 from typing import Protocol
 import warnings
 
@@ -556,7 +557,7 @@ class _LightGBMBaseTuner(_BaseTuner):
         param_name = "feature_fraction"
         best_feature_fraction = self.best_params[param_name]
         param_values: list[float] = cast(
-            list[float],
+            List[float],
             np.linspace(
                 best_feature_fraction - 0.08, best_feature_fraction + 0.08, n_trials
             ).tolist(),


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Follow-up https://github.com/optuna/optuna-integration/pull/212

After merging #212, CI workflows in optuna-integration and optuna-examples became being failed as shown below:

* https://github.com/optuna/optuna-examples/actions/runs/13972510681/job/39117782817
* https://github.com/optuna/optuna-integration/actions/runs/13981048377/job/39146195912

## Description of the changes
<!-- Describe the changes in this PR. -->
Use `typing.List` instead of `list` for Python 3.8 users.