### PR TITLE
Add Pycma Example

### DIFF
--- a/optuna_integration/cma/cma.py
+++ b/optuna_integration/cma/cma.py
@@ -41,26 +41,24 @@ class PyCmaSampler(BaseSampler):
     Note that parallel execution of trials may affect the optimization performance of CMA-ES,
     especially if the number of trials running in parallel exceeds the population size.
 
-    ```python
-    import optuna
-    from optuna.integration import PyCmaSampler
+    .. testcode::
+        import optuna
+        from optuna.integration import PyCmaSampler
 
-    def objective(trial):
-        x = trial.suggest_float("x", -5, 5)
-        y = trial.suggest_float("y", -5, 5)
-        return x**2 + y**2
+        def objective(trial):
+            x = trial.suggest_float("x", -5, 5)
+            y = trial.suggest_float("y", -5, 5)
+            return x**2 + y**2
 
-    # Set up study with CMA-ES
-    sampler = PyCmaSampler(seed=42)
-    study = optuna.create_study(sampler=sampler)
-    study.optimize(objective, n_trials=50)
+        # Set up study with CMA-ES
+        sampler = PyCmaSampler(seed=42)
+        study = optuna.create_study(sampler=sampler)
+        study.optimize(objective, n_trials=50)
 
-    # Print results
-    print("\\nBest trial:")
-    print(f"  Value (minimum f(x,y)): {study.best_value:.5e}")
-    print(f"  Params: {study.best_params}")
-
-    ```
+        # Print results
+        print("\\nBest trial:")
+        print(f"  Value (minimum f(x,y)): {study.best_value:.5e}")
+        print(f"  Params: {study.best_params}")
 
     Args:
 

--- a/optuna_integration/cma/cma.py
+++ b/optuna_integration/cma/cma.py
@@ -42,13 +42,16 @@ class PyCmaSampler(BaseSampler):
     especially if the number of trials running in parallel exceeds the population size.
 
     .. testcode::
+
         import optuna
         from optuna.integration import PyCmaSampler
+
 
         def objective(trial):
             x = trial.suggest_float("x", -5, 5)
             y = trial.suggest_float("y", -5, 5)
             return x**2 + y**2
+
 
         # Set up study with CMA-ES
         sampler = PyCmaSampler(seed=42)

--- a/optuna_integration/cma/cma.py
+++ b/optuna_integration/cma/cma.py
@@ -42,7 +42,6 @@ class PyCmaSampler(BaseSampler):
     especially if the number of trials running in parallel exceeds the population size.
 
     ```python
-    import matplotlib.pyplot as plt
     import optuna
     from optuna.integration import PyCmaSampler
 
@@ -53,27 +52,14 @@ class PyCmaSampler(BaseSampler):
 
     # Set up study with CMA-ES
     sampler = PyCmaSampler(seed=42)
-    study = optuna.create_study(sampler=sampler, direction="minimize")
+    study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=50)
 
     # Print results
     print("\\nBest trial:")
-    print(f"  Value (minimum f(x,y)): {study.best_value:.5f}")
+    print(f"  Value (minimum f(x,y)): {study.best_value:.5e}")
     print(f"  Params: {study.best_params}")
 
-    # Plot the results
-    fig1 = optuna.visualization.matplotlib.plot_param_importances(study).figure
-    fig1.set_size_inches(8, 5)
-    fig1.tight_layout()
-    fig1.savefig("param_importance.png", dpi=300)
-    plt.close(fig1)
-
-    fig2 = optuna.visualization.matplotlib.plot_contour(study, params=["x", "y"]).figure
-    fig2.set_size_inches(8, 5)
-    fig2.suptitle("Contour Plot: f(x, y) = x² + y²")
-    fig2.tight_layout()
-    fig2.savefig("contour_plot.png", dpi=300)
-    plt.close(fig2)
     ```
 
     Args:

--- a/optuna_integration/cma/cma.py
+++ b/optuna_integration/cma/cma.py
@@ -66,29 +66,29 @@ class PyCmaSampler(BaseSampler):
 
         x0:
             A dictionary of an initial parameter values for CMA-ES. By default, the mean of ``low``
-            and ``high`` for each distribution is used. Please refer to `cma.CMAEvolutionStrategy`_
-            for further details of ``x0``.
+            and ``high`` for each distribution is used.
+            Please refer to cma.CMAEvolutionStrategy_ for further details of ``x0``.
 
         sigma0:
             Initial standard deviation of CMA-ES. By default, ``sigma0`` is set to
             ``min_range / 6``, where ``min_range`` denotes the minimum range of the distributions
             in the search space. If distribution is categorical, ``min_range`` is
-            ``len(choices) - 1``. Please refer to `cma.CMAEvolutionStrategy`_ for further details
-            of ``sigma0``.
+            ``len(choices) - 1``.
+            Please refer to cma.CMAEvolutionStrategy_ for further details of ``sigma0``.
 
         cma_stds:
-            A dictionary of multipliers of sigma0 for each parameter. The default value is 1.0.
-            Please refer to `cma.CMAEvolutionStrategy`_ for further details of ``cma_stds``.
+            A dictionary of multipliers of sigma0 for each parameters. The default value is 1.0.
+            Please refer to cma.CMAEvolutionStrategy_ for further details of ``cma_stds``.
 
         seed:
             A random seed for CMA-ES.
 
         cma_opts:
-            Options passed to the constructor of `cma.CMAEvolutionStrategy`_ class.
+            Options passed to the constructor of cma.CMAEvolutionStrategy_ class.
 
-            Note that the default option is `cma_default_options`_.
-            However, ``BoundaryHandler``, ``bounds``, ``CMA_stds`` and ``seed`` arguments in
-            ``cma_opts`` will be ignored because they are added by
+            Note that default option is cma_default_options_,
+            but ``BoundaryHandler``, ``bounds``, ``CMA_stds`` and ``seed`` arguments in
+            ``cma_opts`` will be ignored because it is added by
             :class:`~optuna_integration.PyCmaSampler` automatically.
 
         n_startup_trials:


### PR DESCRIPTION
## Description of the changes

As discussed [here](https://github.com/optuna/optuna-examples/pull/321), I have added the example for pycma in the docstring.

I need some help to correct the docstring formatting.

Could you please review?

cc: @nabenabe0928 