### PR TITLE
lightgbm: add missing spaces in error message about inconsistent intermediate values

### DIFF
--- a/optuna_integration/lightgbm/lightgbm.py
+++ b/optuna_integration/lightgbm/lightgbm.py
@@ -121,15 +121,15 @@ class LightGBMPruningCallback:
             if is_higher_better:
                 if self._trial.study.direction != optuna.study.StudyDirection.MAXIMIZE:
                     raise ValueError(
-                        "The intermediate values are inconsistent with the objective values"
-                        "in terms of study directions. Please specify a metric to be minimized"
+                        "The intermediate values are inconsistent with the objective values "
+                        "in terms of study directions. Please specify a metric to be minimized "
                         "for LightGBMPruningCallback."
                     )
             else:
                 if self._trial.study.direction != optuna.study.StudyDirection.MINIMIZE:
                     raise ValueError(
-                        "The intermediate values are inconsistent with the objective values"
-                        "in terms of study directions. Please specify a metric to be"
+                        "The intermediate values are inconsistent with the objective values "
+                        "in terms of study directions. Please specify a metric to be "
                         "maximized for LightGBMPruningCallback."
                     )
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
This PR just fixes some typo in error messages for the lightgbm integration.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Add missing spaces in ValueError messages about inconsistent intermediate values

