### PR TITLE
Fix numerical issue warning on `qehvi_candidates_func`

### DIFF
--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -436,7 +436,7 @@ def qehvi_candidates_func(
 
     ref_point_list = ref_point.tolist()
 
-    acqf = monte_carlo.qExpectedHypervolumeImprovement(
+    acqf = monte_carlo.qLogExpectedHypervolumeImprovement(
         model=model,
         ref_point=ref_point_list,
         partitioning=partitioning,

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -436,7 +436,12 @@ def qehvi_candidates_func(
 
     ref_point_list = ref_point.tolist()
 
-    acqf = monte_carlo.qLogExpectedHypervolumeImprovement(
+    if hasattr(monte_carlo, 'qLogExpectedHypervolumeImprovement'):
+        hypervol_improvement_method = monte_carlo.qLogExpectedHypervolumeImprovement
+    else:
+        hypervol_improvement_method = monte_carlo.qExpectedHypervolumeImprovement
+
+    acqf = hypervol_improvement_method(
         model=model,
         ref_point=ref_point_list,
         partitioning=partitioning,

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -436,7 +436,7 @@ def qehvi_candidates_func(
 
     ref_point_list = ref_point.tolist()
 
-    if hasattr(monte_carlo, 'qLogExpectedHypervolumeImprovement'):
+    if hasattr(monte_carlo, "qLogExpectedHypervolumeImprovement"):
         hypervol_improvement_method = monte_carlo.qLogExpectedHypervolumeImprovement
     else:
         hypervol_improvement_method = monte_carlo.qExpectedHypervolumeImprovement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ checking = [
 document = [
     "mlflow",
     "pandas",
-    "scikit-learn>=0.24.2",
+    "scikit-learn>=0.24.2,<1.7.1", # TODO(fujimoto): Remove "<1.7.1" once 1.7.2 is released.
     "scipy>=1.9.2; python_version>='3.8'",
     "sphinx",
     "sphinx-notfound-page",


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
I'm getting warnings when running a study with > 1 objectives and no constraints. The warnings say that I should just replace the method with the log version, and there's no reason not to do so.

For more info, see: https://github.com/pytorch/botorch/blob/main/botorch/exceptions/warnings.py#L68

## Description of the changes
Use the qLogExpectedHypervolumeImprovement instead of qExpectedHypervolumeImprovement 
