### PR TITLE
Limit the blackdoc version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ test = [
 ]
 checking = [
   "black<25.9.0", # TODO(nabe): Remove the version constraint after the fix in black.
-  "blackdoc",
+  "blackdoc<0.4.2",  # TODO(y0z): Remove the version constraint after the fix in blackdoc.
   "hacking",
   "isort",
   "mypy",


### PR DESCRIPTION
## Motivation & Description of the changes

- Apply the change as in https://github.com/optuna/optuna/pull/6289.
- Limit the blackdoc version to less than 0.4.2 to fix CI errors.
