### PR TITLE
Exclude Python 3.9 from fastaiv2 CI

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -119,7 +119,7 @@ jobs:
     with:
       integration_name: 'fastaiv2'
       deprecated: false
-      python_matrix: "['3.9', '3.10', '3.11', '3.12', '3.13']"
+      python_matrix: "['3.10', '3.11', '3.12', '3.13']"
       # TODO(c-bata): Remove the version constraint once fastai fixes the dependency error.
       extra_cmds: pip install "ipython"
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Since fastaiv2's dependency spaCy no longer supports Python 3.9, this PR excludes it from CI.

## Description of the changes
<!-- Describe the changes in this PR. -->
Exclude Python 3.9 from fastaiv2 CI.