### PR TITLE
Use `broadcast_object_list` instead of a custom method

### DIFF
--- a/optuna_integration/pytorch_distributed/pytorch_distributed.py
+++ b/optuna_integration/pytorch_distributed/pytorch_distributed.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from datetime import datetime
 import functools
-import pickle
 from typing import Any
 from typing import overload
 from typing import TYPE_CHECKING
@@ -322,26 +321,6 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
         return self._broadcast(result)
 
     def _broadcast(self, value: Any | None) -> Any:
-        buffer = None
-        size_buffer = torch.empty(1, dtype=torch.int)
-        rank = dist.get_rank(self._group)
-        if rank == 0:
-            buffer = _to_tensor(value)
-            size_buffer[0] = buffer.shape[0]
-        dist.broadcast(size_buffer, src=0, group=self._group)
-        buffer_size = int(size_buffer.item())
-        if rank != 0:
-            buffer = torch.empty(buffer_size, dtype=torch.uint8)
-        assert buffer is not None
-        dist.broadcast(buffer, src=0, group=self._group)
-        return _from_tensor(buffer)
-
-
-def _to_tensor(obj: Any) -> "torch.Tensor":
-    b = bytearray(pickle.dumps(obj))
-    return torch.tensor(b, dtype=torch.uint8)
-
-
-def _from_tensor(tensor: "torch.Tensor") -> Any:
-    b = bytearray(tensor.tolist())
-    return pickle.loads(b)
+        obj_list = [value]
+        dist.broadcast_object_list(obj_list, src=0, group=self._group)
+        return obj_list[0]


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
- https://docs.pytorch.org/docs/stable/distributed.html#torch.distributed.broadcast_object_list
The handling of propagating the object in the main process is natively supported by Torch, so we use it instead of the custom method.
This method has been supported since `torch==1.8.0`, which exists even before the Python 3.9 support.
To this end, this does not break the dependency, and we can safely use this function. 

## Description of the changes
<!-- Describe the changes in this PR. -->

- Use `broadcast_object_list` instead of the custom func