### PR TITLE
Use uv in CI to reduce supply chain risk

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -112,7 +112,7 @@ jobs:
       deprecated: false
       python_matrix: "['3.10', '3.11', '3.12', '3.13']"
       # TODO(c-bata): Remove the version constraint once fastai fixes the dependency error.
-      extra_cmds: pip install "ipython"
+      extra_cmds: uv pip install "ipython"
 
   keras:
     if: needs.changes.outputs.keras == 'true'
@@ -185,7 +185,7 @@ jobs:
     with:
       integration_name: 'skorch'
       # TODO: Remove the version constraint once https://github.com/uber/causalml/issues/808 is resolved.
-      extra_cmds: pip install torch "scikit-learn<1.6.0"
+      extra_cmds: uv pip install torch "scikit-learn<1.6.0"
       deprecated: false
 
   tensorboard:
@@ -219,7 +219,7 @@ jobs:
     with:
       integration_name: 'xgboost'
       # TODO: Remove the version constraint once https://github.com/optuna/optuna-integration/issues/216 is resolved.
-      extra_cmds: pip install "xgboost<3.0.0"
+      extra_cmds: uv pip install "xgboost<3.0.0"
       deprecated: false
 
   trackio:

--- a/.github/workflows/checks_template.yml
+++ b/.github/workflows/checks_template.yml
@@ -24,21 +24,17 @@ jobs:
     if: ${{ !inputs.deprecated }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
+          activate-environment: true
+          enable-cache: true
       - name: Check Integration Name
         run: |
           echo "Input is ${{ inputs.integration_name }}"
       - name: Install Common Dependencies
         run: |
-          python -m pip install -U pip
-          pip install --progress-bar off -U .[checking]
-          pip install --progress-bar off -U .[test]
-
-      - name: Install Integration Dependencies
-        run: |
-          pip install --progress-bar off .[${{ inputs.integration_name }}]
+          uv sync --group checking --group test --extra ${{ inputs.integration_name }}
 
       - name: Black
         run: |
@@ -93,21 +89,17 @@ jobs:
     if: ${{ !inputs.deprecated }}
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
+        activate-environment: true
+        enable-cache: true
 
     - name: Install Common Dependencies
       run: |
-        python -m pip install --upgrade pip
-
-        # Install optuna from optuna master
-        pip install git+https://github.com/optuna/optuna@master
-        pip install --progress-bar off .[test]
-
-    - name: Install Integration Dependencies
-      run: |
-        pip install --progress-bar off .[${{ inputs.integration_name }}]
+        uv sync --group test --extra ${{ inputs.integration_name }}
+        # Install optuna from optuna master after sync so it wins over the resolved index version.
+        uv pip install --reinstall git+https://github.com/optuna/optuna@master
 
     - name: Extra Commands
       run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,24 +21,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.10"
+        activate-environment: true
+        enable-cache: true
 
-    - name: Install twine and build
+    - name: Install build tools
       run: |
-        python -m pip install -U pip
-        python -m pip install -U twine build
- 
+        uv pip install build twine
+
     - name: Output installed packages
       run: |
-        pip freeze --all
+        uv pip freeze
  
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
-        pipdeptree
+        uv pip tree
 
     - name: Change the version file for scheduled TestPyPI upload
       if: github.event_name == 'schedule'
@@ -49,7 +48,7 @@ jobs:
 
     - name: Build a tar ball
       run: |
-        python -m build
+        uv build
 
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,23 +15,23 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.10"
+        activate-environment: true
+        enable-cache: true
 
     - name: Install
       run: |
-        python -m pip install -U pip
-        pip install --progress-bar off -U .[checking]
+        uv sync --group checking
 
     - name: Output installed packages
       run: |
-        pip freeze --all
+        uv pip freeze
     
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
-        pipdeptree
+        uv pip tree
 
     - name: Apply formatters
       run: |

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -19,26 +19,25 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v7
       with:
-        python-version: 3.13
+        python-version: "3.13"
+        activate-environment: true
+        enable-cache: true
 
     - name: Install Dependencies
       run: |
-        python -m pip install -U pip
-        pip install --progress-bar off -U .[document]
-
+        uv sync --group document
         # TODO(gen740): Remove this if scikit-learn 1.7.2 is released
-        pip install torch "scikit-learn<1.7.1"
+        uv pip install torch "scikit-learn<1.7.1"
 
     - name: Output installed packages
       run: |
-        pip freeze --all
+        uv pip freeze
 
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
-        pipdeptree
+        uv pip tree
 
     - name: Build Document
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ ENV/
 
 # Sphinx
 docs/source/reference/generated/
+
+# uv
+uv.lock
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Detailed conventions and policies to write, test, and maintain Optuna code are d
 ```bash
 git clone git@github.com:YOUR_NAME/optuna-integration.git
 cd optuna-integration
-pip install -e .
+uv sync
 ```
 
 ### Checking the Format, Coding Style, and Type Hints
@@ -61,23 +61,23 @@ and additional conventions are described in the [Wiki](https://github.com/optuna
 Type hints, [PEP484](https://www.python.org/dev/peps/pep-0484/), are checked with [mypy](http://mypy-lang.org/).
 
 ```bash
-$ pip install ".[checking]"
+$ uv sync --group checking
 # black and isort format
-$ black .
-$ isort .
+$ uv run black .
+$ uv run isort .
 
 # flake8 type checking
-$ flake8 tests optuna_integration
+$ uv run flake8 tests optuna_integration
 
 # mypy type checking
-$ mypy tests optuna_integration 
+$ uv run mypy tests optuna_integration
 ```
 
 You can use `pre-commit` to automatically check the format, coding style, and type hints before committing. The following commands automatically fix format errors by auto-formatters.
 
 ```bash
 # Install `pre-commit`.
-$ pip install pre-commit
+$ uv tool install pre-commit
 
 $ pre-commit install
 $ pre-commit run --all-files
@@ -101,26 +101,26 @@ unit tests are stored under the [tests directory](./tests).
 Please install some required packages at first.
 ```bash
 # Install required packages to test.
-pip install ".[test]"
+uv sync --group test
 
 # Install required packages on which each integration module depends.
-pip install ".[${INTEGRATION_MODULE_NAME}]"
+uv sync --group test --extra ${INTEGRATION_MODULE_NAME}
 
 # For example, for optuna_integration/lightgbm,
-pip install ".[lightgbm]"
+uv sync --group test --extra lightgbm
 ```
 
 You can run your tests as follows:
 
 ```bash
 # Run all the unit tests.
-pytest
+uv run pytest
 
 # Run all the unit tests defined in the specified test file.
-pytest tests/${TARGET_TEST_FILE_NAME}
+uv run pytest tests/${TARGET_TEST_FILE_NAME}
 
 # Run the unit test function with the specified name defined in the specified test file.
-pytest tests/${TARGET_TEST_FILE_NAME} -k ${TARGET_TEST_FUNCTION_NAME}
+uv run pytest tests/${TARGET_TEST_FILE_NAME} -k ${TARGET_TEST_FUNCTION_NAME}
 ```
 
 See also the [Optuna Test Policy](https://github.com/optuna/optuna/wiki/Test-Policy), which describes the principles to write and maintain Optuna tests to meet certain quality requirements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,33 +32,6 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = [
-  "pytest",
-  "coverage",
-  "fakeredis[lua]",
-  "grpcio",
-  "protobuf>=5.28.1",
-]
-checking = [
-  "black<25.9.0", # TODO(nabe): Remove the version constraint after the fix in black.
-  "blackdoc<0.4.2",  # TODO(y0z): Remove the version constraint after the fix in blackdoc.
-  "hacking",
-  "isort",
-  "mypy",
-  "types-PyYAML",
-  "types-redis",
-  "types-setuptools",
-  "typing_extensions>=3.10.0.0",
-]
-document = [
-    "mlflow",
-    "pandas",
-    "scikit-learn>=0.24.2",
-    "scipy>=1.9.2; python_version>='3.9'",
-    "sphinx",
-    "sphinx-notfound-page",
-    "sphinx_rtd_theme",
-]
 allennlp = [
     "allennlp",
     "jsonnet",
@@ -161,6 +134,35 @@ trackio = [
     "trackio",
 ]
 
+[dependency-groups]
+test = [
+  "pytest",
+  "coverage",
+  "fakeredis[lua]",
+  "grpcio",
+  "protobuf>=5.28.1",
+]
+checking = [
+  "black<25.9.0", # TODO(nabe): Remove the version constraint after the fix in black.
+  "blackdoc<0.4.2",  # TODO(y0z): Remove the version constraint after the fix in blackdoc.
+  "hacking",
+  "isort",
+  "mypy",
+  "types-PyYAML",
+  "types-redis",
+  "types-setuptools",
+  "typing_extensions>=3.10.0.0",
+]
+document = [
+  "mlflow",
+  "pandas",
+  "scikit-learn>=0.24.2",
+  "scipy>=1.9.2; python_version>='3.9'",
+  "sphinx",
+  "sphinx-notfound-page",
+  "sphinx_rtd_theme",
+]
+
 [project.urls]
 repository = "https://github.com/optuna/optuna-integration"
 
@@ -170,6 +172,10 @@ include = ["optuna_integration*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "optuna_integration.version.__version__"}
+
+[tool.uv]
+exclude-newer = "5 days"
+exclude-newer-package = {optuna = false}
 
 [tool.black]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,11 @@ version = {attr = "optuna_integration.version.__version__"}
 exclude-newer = "5 days"
 exclude-newer-package = {optuna = false}
 
+[tool.uv.extra-build-dependencies]
+# Chainer's legacy build backend imports `pkg_resources` without declaring it,
+# and uv may evaluate the extra during dependency resolution in CI.
+chainer = ["setuptools"]
+
 [tool.black]
 line-length = 99
 target-version = ['py39']


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
A recent supply chain attack in the PyTorch Lightning ecosystem highlighted the risk of resolving very new package releases in CI. This updates our dependency management to use uv, so we can apply `exclude-newer`.

## Description of the changes
<!-- Describe the changes in this PR. -->

- Migrate GitHub Actions from pip-based installation to uv, including setup-uv, uv sync, uv pip freeze, uv pip tree, and uv build.
- Add `tool.uv.exclude-newer = "5 days"` with explicit exceptions for optuna.
- Move test, checking, and document dependencies from project.optional-dependencies to dependency-groups, and update contributor docs accordingly.
