### PR TITLE
Add deprecation message for `CometCallback`

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -38,14 +38,6 @@ chainermn:
   - '.github/file-filters.yml'
   - 'pyproject.toml'
 
-comet:
-  - 'optuna_integration/comet/**'
-  - 'tests/comet/**'
-  - '.github/workflows/checks.yml'
-  - '.github/workflows/checks_template.yml'
-  - '.github/file-filters.yml'
-  - 'pyproject.toml'
-
 dask:
   - 'optuna_integration/dask/**'
   - 'tests/dask/**'

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -23,7 +23,6 @@ jobs:
       catboost: ${{ steps.changes.outputs.catboost }}
       chainer: ${{ steps.changes.outputs.chainer }}
       chainermn: ${{ steps.changes.outputs.chainermn }}
-      comet: ${{ steps.changes.outputs.comet }}
       dask: ${{ steps.changes.outputs.dask }}
       fastaiv2: ${{ steps.changes.outputs.fastaiv2 }}
       keras: ${{ steps.changes.outputs.keras }}
@@ -86,14 +85,6 @@ jobs:
     with:
       integration_name: 'chainermn'
       deprecated: true
-
-  comet:
-    if: needs.changes.outputs.comet == 'true'
-    needs: changes
-    uses: ./.github/workflows/checks_template.yml
-    with:
-      integration_name: 'comet'
-      deprecated: false
 
   dask:
     if: needs.changes.outputs.dask == 'true'

--- a/optuna_integration/comet/comet.py
+++ b/optuna_integration/comet/comet.py
@@ -8,7 +8,7 @@ import functools
 import json
 
 import optuna
-from optuna._experimental import experimental_class
+from optuna._deprecated import deprecated_class
 from optuna.study.study import ObjectiveFuncType
 
 from optuna_integration._imports import try_import
@@ -18,7 +18,7 @@ with try_import() as _imports:
     import comet_ml
 
 
-@experimental_class("4.0.0")
+@deprecated_class("4.9.0", "6.0.0")
 class CometCallback:
     """
     A callback for logging Optuna study trials to a Comet ML Experiment.


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

We plan to move callback-style integrations to OptunaHub now that it has a dedicated callbacks category. One example already migrated there is the Weights & Biases callback: https://github.com/optuna/optunahub-registry/pull/364

## Description of the changes

- Mark optuna_integration.comet.CometCallback as deprecated with @deprecated_class("4.9.0", "6.0.0").
- Remove the CI workflow for comet.
- Do not mention OptunaHub in the deprecation message yet, since the submitting a pull request to optunahub-registry is still future work.