### PR TITLE
Add deprecation message for TensorBoardCallback

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -134,14 +134,6 @@ skorch:
   - '.github/file-filters.yml'
   - 'pyproject.toml'
 
-tensorboard:
-  - 'optuna_integration/tensorboard/**'
-  - 'tests/tensorboard/**'
-  - '.github/workflows/checks.yml'
-  - '.github/workflows/checks_template.yml'
-  - '.github/file-filters.yml'
-  - 'pyproject.toml'
-
 tensorflow:
   - 'optuna_integration/tensorflow/**'
   - 'tests/tensorflow/**'

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -34,7 +34,6 @@ jobs:
       shap: ${{ steps.changes.outputs.shap }}
       sklearn: ${{ steps.changes.outputs.sklearn }}
       skorch: ${{ steps.changes.outputs.skorch }}
-      tensorboard: ${{ steps.changes.outputs.tensorboard }}
       tfkeras: ${{ steps.changes.outputs.tfkeras }}
       wandb: ${{ steps.changes.outputs.wandb }}
       xgboost: ${{ steps.changes.outputs.xgboost }}
@@ -177,14 +176,6 @@ jobs:
       integration_name: 'skorch'
       # TODO: Remove the version constraint once https://github.com/uber/causalml/issues/808 is resolved.
       extra_cmds: pip install torch "scikit-learn<1.6.0"
-      deprecated: false
-
-  tensorboard:
-    if: needs.changes.outputs.tensorboard == 'true'
-    needs: changes
-    uses: ./.github/workflows/checks_template.yml
-    with:
-      integration_name: 'tensorboard'
       deprecated: false
 
   tfkeras:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Here is the table of `optuna-integration` modules:
 |[SHAP](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#shap)|[SHAP Importance Evaluator](https://github.com/optuna/optuna-integration/blob/v4.4.0/optuna_integration/shap/shap.py#L29-L45)|
 |[scikit-learn](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#sklearn)|[OptunaSearchCV](https://github.com/optuna/optuna-examples/tree/main/sklearn/sklearn_optuna_search_cv_simple.py)|
 |[skorch](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#skorch)|[SkorchPruningCallback](https://github.com/optuna/optuna-examples/tree/main/pytorch/skorch_simple.py)|
-|[TensorBoard](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorboard)|[TensorBoardCallback](https://github.com/optuna/optuna-examples/tree/main/tensorboard/tensorboard_simple.py)|
+|[TensorBoard](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorboard)*|[TensorBoardCallback](https://github.com/optuna/optuna-examples/tree/main/tensorboard/tensorboard_simple.py)|
 |[tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)|[TFKerasPruningCallback](https://github.com/optuna/optuna-examples/tree/main/tfkeras/tfkeras_integration.py)|
 |[Weights & Biases](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#wandb)|[WeightsAndBiasesCallback](https://github.com/optuna/optuna-examples/blob/main/wandb/wandb_integration.py)|
 |[XGBoost](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#xgboost)|[XGBoostPruningCallback](https://github.com/optuna/optuna-examples/tree/main/xgboost/xgboost_integration.py)|

--- a/optuna_integration/tensorboard/tensorboard.py
+++ b/optuna_integration/tensorboard/tensorboard.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 import optuna
-from optuna._experimental import experimental_class
+from optuna._deprecated import deprecated_class
 from optuna.logging import get_logger
 
 from optuna_integration._imports import try_import
@@ -16,7 +16,7 @@ with try_import() as _imports:
 _logger = get_logger(__name__)
 
 
-@experimental_class("2.0.0")
+@deprecated_class("4.9.0", "6.0.0")
 class TensorBoardCallback:
     """Callback to track Optuna trials with TensorBoard.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

refs https://github.com/optuna/optuna-integration/pull/280

We plan to move callback-style integrations to OptunaHub now that it has a dedicated callbacks category. One example already migrated there is the Weights & Biases callback: https://github.com/optuna/optunahub-registry/pull/364

## Description of the changes

- Mark `TensorBoardCallback` as deprecated with `@deprecated_class("4.9.0", "6.0.0").`
- Remove the CI workflow for tensor board.
- Do not mention OptunaHub in the deprecation message yet, since the submitting a pull request to optunahub-registry is still future work.