### PR TITLE
Add deprecation message for `WeightsAndBiasesCallback`

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -142,14 +142,6 @@ tfkeras:
   - '.github/file-filters.yml'
   - 'pyproject.toml'
 
-wandb:
-  - 'optuna_integration/wandb/**'
-  - 'tests/wandb/**'
-  - '.github/workflows/checks.yml'
-  - '.github/workflows/checks_template.yml'
-  - '.github/file-filters.yml'
-  - 'pyproject.toml'
-
 xgboost:
   - 'optuna_integration/xgboost/**'
   - 'tests/xgboost/**'

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -34,7 +34,6 @@ jobs:
       sklearn: ${{ steps.changes.outputs.sklearn }}
       skorch: ${{ steps.changes.outputs.skorch }}
       tfkeras: ${{ steps.changes.outputs.tfkeras }}
-      wandb: ${{ steps.changes.outputs.wandb }}
       xgboost: ${{ steps.changes.outputs.xgboost }}
     steps:
       - uses: actions/checkout@v4
@@ -174,14 +173,6 @@ jobs:
     uses: ./.github/workflows/checks_template.yml
     with:
       integration_name: 'tfkeras'
-      deprecated: false
-
-  wandb:
-    if: needs.changes.outputs.wandb == 'true'
-    needs: changes
-    uses: ./.github/workflows/checks_template.yml
-    with:
-      integration_name: 'wandb'
       deprecated: false
 
   xgboost:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here is the table of `optuna-integration` modules:
 |[skorch](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#skorch)|[SkorchPruningCallback](https://github.com/optuna/optuna-examples/tree/main/pytorch/skorch_simple.py)|
 |[TensorBoard](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorboard)*|[TensorBoardCallback](https://github.com/optuna/optuna-examples/tree/main/tensorboard/tensorboard_simple.py)|
 |[tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)|[TFKerasPruningCallback](https://github.com/optuna/optuna-examples/tree/main/tfkeras/tfkeras_integration.py)|
-|[Weights & Biases](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#wandb)|[WeightsAndBiasesCallback](https://github.com/optuna/optuna-examples/blob/main/wandb/wandb_integration.py)|
+|[Weights & Biases](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#wandb)*|[WeightsAndBiasesCallback](https://github.com/optuna/optuna-examples/blob/main/wandb/wandb_integration.py)|
 |[XGBoost](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#xgboost)|[XGBoostPruningCallback](https://github.com/optuna/optuna-examples/tree/main/xgboost/xgboost_integration.py)|
 |[Trackio](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#trackio)*|[TrackioCallback](https://github.com/optuna/optuna-integration/tree/main/optuna_integration/trackio/trackio.py)|
 |[AllenNLP](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#allennlp)*|[AllenNLPPruningCallback](https://github.com/optuna/optuna-examples/blob/main/allennlp/allennlp_simple.py)|

--- a/optuna_integration/wandb/wandb.py
+++ b/optuna_integration/wandb/wandb.py
@@ -7,7 +7,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 import optuna
-from optuna._experimental import experimental_class
+from optuna._deprecated import deprecated_class
 from optuna._experimental import experimental_func
 from optuna._imports import try_import
 
@@ -20,7 +20,7 @@ with try_import() as _imports:
     import wandb
 
 
-@experimental_class("2.9.0")
+@deprecated_class("4.9.0", "6.0.0")
 class WeightsAndBiasesCallback:
     """Callback to track Optuna trials with Weights & Biases.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

We plan to move callback-style integrations to OptunaHub now that it has a dedicated callbacks category. Weights & Biases callback is already migrated to OptunaHub at https://github.com/optuna/optunahub-registry/pull/364.

## Description of the changes
<!-- Describe the changes in this PR. -->
- Mark `WeightsAndBiasesCallback` as deprecated with `@deprecated_class("4.9.0", "6.0.0").`
- Remove the CI workflow for tensor board.
- Although the WeightsAndBiases callback has already been migrated to OptunaHub, the deprecation message in this PR does not point users there yet. It is not listed on https://hub.optuna.org/ for now because the necessary support in https://github.com/optuna/optunahub-web is still in progress.