### PR TITLE
Add deprecation message for TrackioCallback

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -158,10 +158,3 @@ xgboost:
   - '.github/file-filters.yml'
   - 'pyproject.toml'
 
-trackio:
-  - 'optuna_integration/trackio/**'
-  - 'tests/trackio/**'
-  - '.github/workflows/checks.yml'
-  - '.github/workflows/checks_template.yml'
-  - '.github/file-filters.yml'
-  - 'pyproject.toml'

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -36,7 +36,6 @@ jobs:
       tfkeras: ${{ steps.changes.outputs.tfkeras }}
       wandb: ${{ steps.changes.outputs.wandb }}
       xgboost: ${{ steps.changes.outputs.xgboost }}
-      trackio: ${{ steps.changes.outputs.trackio }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -195,11 +194,3 @@ jobs:
       extra_cmds: pip install "xgboost<3.0.0"
       deprecated: false
 
-  trackio:
-    if: needs.changes.outputs.trackio == 'true'
-    needs: changes
-    uses: ./.github/workflows/checks_template.yml
-    with:
-      integration_name: 'trackio'
-      deprecated: false
-      python_matrix: "['3.10', '3.11', '3.12', '3.13']"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Here is the table of `optuna-integration` modules:
 |[tf.keras](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#tensorflow)|[TFKerasPruningCallback](https://github.com/optuna/optuna-examples/tree/main/tfkeras/tfkeras_integration.py)|
 |[Weights & Biases](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#wandb)|[WeightsAndBiasesCallback](https://github.com/optuna/optuna-examples/blob/main/wandb/wandb_integration.py)|
 |[XGBoost](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#xgboost)|[XGBoostPruningCallback](https://github.com/optuna/optuna-examples/tree/main/xgboost/xgboost_integration.py)|
-|[Trackio](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#trackio)|[TrackioCallback](https://github.com/optuna/optuna-integration/tree/main/optuna_integration/trackio/trackio.py)|
+|[Trackio](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#trackio)*|[TrackioCallback](https://github.com/optuna/optuna-integration/tree/main/optuna_integration/trackio/trackio.py)|
 |[AllenNLP](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#allennlp)*|[AllenNLPPruningCallback](https://github.com/optuna/optuna-examples/blob/main/allennlp/allennlp_simple.py)|
 |[Chainer](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainer)*|[ChainerPruningExtension](https://github.com/optuna/optuna-examples/tree/main/chainer/chainer_integration.py)|
 |[ChainerMN](https://optuna-integration.readthedocs.io/en/stable/reference/index.html#chainermn)* | [ChainerMNStudy](https://github.com/optuna/optuna-examples/tree/main/chainer/chainermn_simple.py) |

--- a/optuna_integration/trackio/trackio.py
+++ b/optuna_integration/trackio/trackio.py
@@ -8,7 +8,7 @@ from typing import cast
 from typing import TYPE_CHECKING
 
 import optuna
-from optuna._experimental import experimental_class
+from optuna._deprecated import deprecated_class
 from optuna._imports import try_import
 
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from optuna.study.study import ObjectiveFuncType
 
 
-@experimental_class("4.7.0")
+@deprecated_class("4.9.0", "6.0.0")
 class TrackioCallback:
     """Callback to track Optuna trials with Trackio.
 


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

@ParagEkbote, first of all, I would like to apologize for deprecating TrackioCallback so soon after it was introduced.

The background is that optuna-integration is currently moving toward a smaller maintenance scope. Due to the rapid increase in supply chain attacks in recent years, and because it has become increasingly difficult for the Optuna maintainers to ensure the quality and long-term maintenance of a growing number of third-party integrations, we are gradually reducing the surface area of this package.

As part of that direction, we would like to encourage callback-style integrations to be distributed via OptunaHub, which is a platform where users can freely publish and maintain Optuna-related features. For example, the Weights & Biases callback, which is planned to be deprecated in https://github.com/optuna/optuna-integration/pull/283, has already been added to OptunaHub in https://github.com/optuna/optunahub-registry/pull/364.

If @ParagEkbote is open to it, we would very much appreciate a PR to [optunahub-registry](https://github.com/optuna/optunahub-registry) for `TrackioCallback` as well, similar to the Weights & Biases callback. There is also a tutorial for publishing callbacks to OptunaHub here:
https://optuna.github.io/optunahub/generated/recipes/008_callbacks.html

## Description of the changes
<!-- Describe the changes in this PR. -->
* Mark `TrackioCallback` as deprecated with `@deprecated_class("4.9.0", "6.0.0").`
* Remove the CI workflow for `TrackioCallback`.
* Do not mention OptunaHub in the deprecation message yet, since the submitting a pull request to optunahub-registry is still future work.