### PR TITLE
Fix the release workflow for v4.9.0.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -51,13 +51,6 @@ jobs:
       run: |
         python -m build
 
-    - name: Publish distribution to TestPyPI
-      # The following upload action cannot be executed in the forked repository.
-      if: (github.event_name == 'schedule') || (github.event_name == 'release')
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-      with:
-          repository-url: https://test.pypi.org/legacy/
-
     - name: Publish distribution to PyPI
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -62,3 +62,7 @@ jobs:
       # The following upload action cannot be executed in the forked repository.
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+      with:
+        # See https://github.com/pypa/gh-action-pypi-publish/issues/283
+        attestations: false
+


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The release of optuna-integration v4.9.0 is failed due to the issue related to https://github.com/pypa/gh-action-pypi-publish/issues/283. This PR updates the release branch to resolve the error.
https://github.com/optuna/optuna-integration/actions/runs/26386022798/job/77664595777

## Description of the changes
<!-- Describe the changes in this PR. -->
This PR include two changes:

1. Add `attestations: false` to fix the error, which is the backport of #291.
2. Remove the step to release to the testpypi since v4.9.0 was already successfully released (See https://test.pypi.org/project/optuna-integration/4.9.0/).