### PR TITLE
Migrate CI and development setup to uv

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -33,8 +33,8 @@ jobs:
       tfkeras: ${{ steps.changes.outputs.tfkeras }}
       xgboost: ${{ steps.changes.outputs.xgboost }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: .github/file-filters.yml

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -72,7 +72,7 @@ jobs:
       deprecated: false
       python_matrix: "['3.10', '3.11', '3.12', '3.13']"
       # TODO(c-bata): Remove the version constraint once fastai fixes the dependency error.
-      extra_cmds: pip install "ipython"
+      extra_cmds: uv pip install "ipython"
 
   keras:
     if: needs.changes.outputs.keras == 'true'
@@ -137,7 +137,7 @@ jobs:
     with:
       integration_name: 'skorch'
       # TODO: Remove the version constraint once https://github.com/uber/causalml/issues/808 is resolved.
-      extra_cmds: pip install torch "scikit-learn<1.6.0"
+      extra_cmds: uv pip install torch "scikit-learn<1.6.0"
       deprecated: false
 
   tfkeras:
@@ -155,6 +155,5 @@ jobs:
     with:
       integration_name: 'xgboost'
       # TODO: Remove the version constraint once https://github.com/optuna/optuna-integration/issues/216 is resolved.
-      extra_cmds: pip install "xgboost<3.0.0"
+      extra_cmds: uv pip install "xgboost<3.0.0"
       deprecated: false
-

--- a/.github/workflows/checks_template.yml
+++ b/.github/workflows/checks_template.yml
@@ -24,10 +24,10 @@ jobs:
     if: ${{ !inputs.deprecated }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: '3.10'
+          enable-cache: true
       - name: Check Integration Name
         run: |
           echo "Input is ${{ inputs.integration_name }}"
@@ -88,10 +88,10 @@ jobs:
     if: ${{ !inputs.deprecated }}
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        enable-cache: true
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/checks_template.yml
+++ b/.github/workflows/checks_template.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !inputs.deprecated }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
@@ -87,8 +87,8 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_matrix) }}
     if: ${{ !inputs.deprecated }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0

--- a/.github/workflows/checks_template.yml
+++ b/.github/workflows/checks_template.yml
@@ -27,62 +27,57 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       - name: Check Integration Name
         run: |
           echo "Input is ${{ inputs.integration_name }}"
-      - name: Install Common Dependencies
+      - name: Install Dependencies
         run: |
-          python -m pip install -U pip
-          pip install --progress-bar off -U .[checking]
-          pip install --progress-bar off -U .[test]
-
-      - name: Install Integration Dependencies
-        run: |
-          pip install --progress-bar off .[${{ inputs.integration_name }}]
+          uv sync --group checking --group test --extra "${{ inputs.integration_name }}"
 
       - name: Black
         run: |
           if [ -e optuna_integration/${{ inputs.integration_name }} ]; then
-            black optuna_integration/${{ inputs.integration_name }} --check --diff
+            uv run black optuna_integration/${{ inputs.integration_name }} --check --diff
           fi
           if [ -e tests/${{ inputs.integration_name }} ]; then
-            black tests/${{ inputs.integration_name }} --check --diff
+            uv run black tests/${{ inputs.integration_name }} --check --diff
           fi
 
       - name: Import Sorting
         run: |
           if [ -e optuna_integration/${{ inputs.integration_name }} ]; then
-            isort optuna_integration/${{ inputs.integration_name }} --check --diff
+            uv run isort optuna_integration/${{ inputs.integration_name }} --check --diff
           fi
           if [ -e tests/${{ inputs.integration_name }} ]; then
-            isort tests/${{ inputs.integration_name }} --check --diff
+            uv run isort tests/${{ inputs.integration_name }} --check --diff
           fi
 
       - name: MyPy
         run: |
           if [ -e optuna_integration/${{ inputs.integration_name }} ]; then
-            mypy optuna_integration/${{ inputs.integration_name }}
+            uv run mypy optuna_integration/${{ inputs.integration_name }}
           fi
           if [ -e tests/${{ inputs.integration_name }} ]; then
-            mypy tests/${{ inputs.integration_name }}
+            uv run mypy tests/${{ inputs.integration_name }}
           fi
 
       - name: BlackDoc
         run: |
           if [ -e optuna_integration/${{ inputs.integration_name }} ]; then
-            blackdoc optuna_integration/${{ inputs.integration_name }} --check --diff
+            uv run blackdoc optuna_integration/${{ inputs.integration_name }} --check --diff
           fi
           if [ -e tests/${{ inputs.integration_name }} ]; then
-            blackdoc tests/${{ inputs.integration_name }} --check --diff
+            uv run blackdoc tests/${{ inputs.integration_name }} --check --diff
           fi
 
       - name: Flake8
         run: |
           if [ -e optuna_integration/${{ inputs.integration_name }} ]; then
-            flake8 optuna_integration/${{ inputs.integration_name }}
+            uv run flake8 optuna_integration/${{ inputs.integration_name }}
           fi
           if [ -e tests/${{ inputs.integration_name }} ]; then
-            flake8 tests/${{ inputs.integration_name }}
+            uv run flake8 tests/${{ inputs.integration_name }}
           fi
 
   tests:
@@ -96,18 +91,14 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
-    - name: Install Common Dependencies
+    - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
+        uv sync --group test --extra "${{ inputs.integration_name }}"
 
         # Install optuna from optuna master
-        pip install git+https://github.com/optuna/optuna@master
-        pip install --progress-bar off .[test]
-
-    - name: Install Integration Dependencies
-      run: |
-        pip install --progress-bar off .[${{ inputs.integration_name }}]
+        uv pip install git+https://github.com/optuna/optuna@master
 
     - name: Extra Commands
       run: |
@@ -116,5 +107,5 @@ jobs:
     - name: Tests
       run: |
         if [ -e tests/${{ inputs.integration_name }} ]; then
-          pytest tests/${{ inputs.integration_name }}
+          uv run pytest tests/${{ inputs.integration_name }}
         fi

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -26,6 +26,11 @@ jobs:
       with:
         python-version: "3.13"
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      with:
+        python-version: '3.13'
+        enable-cache: 'false'
+        restore-cache: 'false'
+        cache-python: 'false'
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -25,20 +25,19 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: "3.13"
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
-    - name: Install twine and build
+    - name: Install Dependencies
       run: |
-        python -m pip install -U pip
-        python -m pip install -U twine build
+        uv sync --group publish --group pipdeptree
  
     - name: Output installed packages
       run: |
-        pip freeze --all
+        uv pip freeze
  
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
-        pipdeptree
+        uv run pipdeptree
 
     - name: Change the version file for scheduled TestPyPI upload
       if: github.event_name == 'schedule'
@@ -49,7 +48,7 @@ jobs:
 
     - name: Build a tar ball
       run: |
-        python -m build
+        uv run python -m build
 
     - name: Publish distribution to TestPyPI
       # The following upload action cannot be executed in the forked repository.
@@ -65,4 +64,3 @@ jobs:
       with:
         # See https://github.com/pypa/gh-action-pypi-publish/issues/283
         attestations: false
-

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,16 +21,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - name: Set up Python 3.13
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-      with:
-        python-version: "3.13"
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: '3.13'
-        enable-cache: 'false'
-        restore-cache: 'false'
-        cache-python: 'false'
+        enable-cache: false
+        restore-cache: false
+        cache-python: false
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,26 +18,25 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.10"
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
     - name: Install
       run: |
-        python -m pip install -U pip
-        pip install --progress-bar off -U .[checking]
+        uv sync --group checking --group pipdeptree
 
     - name: Output installed packages
       run: |
-        pip freeze --all
+        uv pip freeze
     
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
-        pipdeptree
+        uv run pipdeptree
 
     - name: Apply formatters
       run: |
-        black .
-        blackdoc .
-        isort .
+        uv run black .
+        uv run blackdoc .
+        uv run isort .
 
     - name: Reviewdog
       uses: reviewdog/action-suggester@v1

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,10 +15,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v6
-      with:
-        python-version: "3.10"
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      with:
+        python-version: '3.10'
 
     - name: Install
       run: |
@@ -27,7 +26,7 @@ jobs:
     - name: Output installed packages
       run: |
         uv pip freeze
-    
+
     - name: Output dependency tree
       run: |
         uv run pipdeptree

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.13
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -38,6 +38,9 @@ jobs:
 
     - name: Build Document
       env:
+        # NOTE(gen740): Sphinx autodoc imports MLflowCallback, and MLflow pulls
+        # opentelemetry-proto 1.11.1, whose _pb2.py files fail with protobuf 7.x's
+        # default upb runtime. Use the pure-Python protobuf runtime for docs.
         PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
       run: |
         uv run make -C docs html

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -37,6 +37,8 @@ jobs:
         uv run pipdeptree
 
     - name: Build Document
+      env:
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
       run: |
         uv run make -C docs html
 

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -19,10 +19,10 @@ jobs:
 
     - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v6
-      with:
-        python-version: 3.13
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      with:
+        python-version: '3.13'
+        enable-cache: true
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -22,29 +22,23 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.13
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
     - name: Install Dependencies
       run: |
-        python -m pip install -U pip
-        pip install --progress-bar off -U .[document]
-
-        # TODO(gen740): Remove this if scikit-learn 1.7.2 is released
-        pip install torch "scikit-learn<1.7.1"
+        uv sync --extra document --group pipdeptree
 
     - name: Output installed packages
       run: |
-        pip freeze --all
+        uv pip freeze
 
     - name: Output dependency tree
       run: |
-        pip install pipdeptree
-        pipdeptree
+        uv run pipdeptree
 
     - name: Build Document
       run: |
-        cd docs
-        make html
-        cd ../
+        uv run make -C docs html
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 
 # Sphinx
 docs/source/reference/generated/
+
+# uv
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # pre-commit package installation is necessary to use pre-commit.
-# $ pip install pre-commit
-# $ pre-commit install
+# $ uv sync --group checking
+# $ uv run pre-commit install
 
 default_language_version:
   python: python3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Detailed conventions and policies to write, test, and maintain Optuna code are d
 ```bash
 git clone git@github.com:YOUR_NAME/optuna-integration.git
 cd optuna-integration
-pip install -e .
+uv sync
 ```
 
 ### Checking the Format, Coding Style, and Type Hints
@@ -61,26 +61,24 @@ and additional conventions are described in the [Wiki](https://github.com/optuna
 Type hints, [PEP484](https://www.python.org/dev/peps/pep-0484/), are checked with [mypy](http://mypy-lang.org/).
 
 ```bash
-$ pip install ".[checking]"
+$ uv sync --group checking
 # black and isort format
-$ black .
-$ isort .
+$ uv run black .
+$ uv run isort .
 
 # flake8 type checking
-$ flake8 tests optuna_integration
+$ uv run flake8 tests optuna_integration
 
 # mypy type checking
-$ mypy tests optuna_integration 
+$ uv run mypy tests optuna_integration
 ```
 
 You can use `pre-commit` to automatically check the format, coding style, and type hints before committing. The following commands automatically fix format errors by auto-formatters.
 
 ```bash
-# Install `pre-commit`.
-$ pip install pre-commit
-
-$ pre-commit install
-$ pre-commit run --all-files
+$ uv sync --group checking
+$ uv run pre-commit install
+$ uv run pre-commit run --all-files
 ```
 
 ### Documentation
@@ -101,26 +99,26 @@ unit tests are stored under the [tests directory](./tests).
 Please install some required packages at first.
 ```bash
 # Install required packages to test.
-pip install ".[test]"
+uv sync --group test
 
 # Install required packages on which each integration module depends.
-pip install ".[${INTEGRATION_MODULE_NAME}]"
+uv sync --group test --extra "${INTEGRATION_MODULE_NAME}"
 
 # For example, for optuna_integration/lightgbm,
-pip install ".[lightgbm]"
+uv sync --group test --extra lightgbm
 ```
 
 You can run your tests as follows:
 
 ```bash
 # Run all the unit tests.
-pytest
+uv run pytest
 
 # Run all the unit tests defined in the specified test file.
-pytest tests/${TARGET_TEST_FILE_NAME}
+uv run pytest tests/${TARGET_TEST_FILE_NAME}
 
 # Run the unit test function with the specified name defined in the specified test file.
-pytest tests/${TARGET_TEST_FILE_NAME} -k ${TARGET_TEST_FUNCTION_NAME}
+uv run pytest tests/${TARGET_TEST_FILE_NAME} -k ${TARGET_TEST_FUNCTION_NAME}
 ```
 
 See also the [Optuna Test Policy](https://github.com/optuna/optuna/wiki/Test-Policy), which describes the principles to write and maintain Optuna tests to meet certain quality requirements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,24 +32,6 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = [
-  "pytest",
-  "coverage",
-  "fakeredis[lua]",
-  "grpcio",
-  "protobuf>=5.28.1",
-]
-checking = [
-  "black<25.9.0", # TODO(nabe): Remove the version constraint after the fix in black.
-  "blackdoc<0.4.2",  # TODO(y0z): Remove the version constraint after the fix in blackdoc.
-  "hacking",
-  "isort",
-  "mypy",
-  "types-PyYAML",
-  "types-redis",
-  "types-setuptools",
-  "typing_extensions>=3.10.0.0",
-]
 document = [
     "mlflow",
     "pandas",
@@ -63,11 +45,11 @@ botorch = [
     "botorch<0.10.0",
 ]
 catboost = [
-    "numpy<2.0.0",  # TODO(nabe): Remove this constraint once this issue is resolved. https://github.com/numpy/numpy/issues/26710
+    "numpy",
     "catboost",
 ]
 cma = [
-    "numpy<2.0.0",  # TODO(nabe): Remove this constraint once this issue is resolved. https://github.com/numpy/numpy/issues/26710
+    "numpy",
     "cma",
 ]
 comet = [
@@ -84,7 +66,7 @@ fastaiv2 = [
     "fastcore<1.12.2",  # TODO(not522): Remove this constraint once this issue is resolved. https://github.com/AnswerDotAI/fastcore/issues/751
 ]
 keras = [
-    "tensorflow",
+    "tensorflow>=2.20.0",
 ]
 lightgbm = [
     "lightgbm",
@@ -115,7 +97,8 @@ pytorch-lightning = [
     "lightning",
 ]
 shap = [
-    "numpy<2.0.0",  # TODO(nabe): Remove this constraint once this issue is resolved. https://github.com/numpy/numpy/issues/26710
+    "numba>=0.60.0",
+    "numpy",
     "shap",
 ]
 sklearn = [
@@ -129,13 +112,13 @@ skorch = [
 ]
 tensorboard = [
     "tensorboard",
-    "tensorflow",
+    "tensorflow>=2.20.0",
 ]
 tensorflow = [
-    "tensorflow<=2.15.0",
+    "tensorflow>=2.20.0",
 ]
 tfkeras = [
-    "tensorflow",
+    "tensorflow>=2.20.0",
 ]
 wandb = [
     "wandb",
@@ -144,11 +127,44 @@ xgboost = [
     "xgboost",
 ]
 trackio = [
-    "trackio",
+    "trackio; python_version>='3.10'",
+]
+
+[dependency-groups]
+test = [
+  "pytest",
+  "coverage",
+  "fakeredis[lua]",
+  "grpcio",
+  "protobuf>=5.28.1",
+]
+checking = [
+  "black<25.9.0", # TODO(nabe): Remove the version constraint after the fix in black.
+  "blackdoc<0.4.2",  # TODO(y0z): Remove the version constraint after the fix in blackdoc.
+  "hacking",
+  "isort",
+  "mypy",
+  "pre-commit",
+  "types-PyYAML",
+  "types-redis",
+  "types-setuptools",
+  "typing_extensions>=3.10.0.0",
+]
+pipdeptree = [
+  "pipdeptree",
+]
+publish = [
+  "build",
+  "twine",
 ]
 
 [project.urls]
 repository = "https://github.com/optuna/optuna-integration"
+
+[tool.uv]
+default-groups = []
+exclude-newer = "5 days"
+exclude-newer-package = { torch = false, optuna = false, optuna-integration = false }
 
 [tool.setuptools.packages.find]
 # where = ["."]


### PR DESCRIPTION
## Motivation

Use `uv` instead of `pip` for faster and more reproducible dependency installation. Also use `exclude-newer = "5 days"` to reduce exposure to very recently published packages.

## Description of the changes

- Replace `pip` installs in CI and docs with `uv sync` / `uv run`.
- Move test/check dependencies to dependency groups.
- Add `uv` settings including `exclude-newer = "5 days"`.