### PR TITLE
Specify action hash in workflow files

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -39,8 +39,8 @@ jobs:
       tfkeras: ${{ steps.changes.outputs.tfkeras }}
       xgboost: ${{ steps.changes.outputs.xgboost }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: changes
         with:
           filters: .github/file-filters.yml

--- a/.github/workflows/checks_template.yml
+++ b/.github/workflows/checks_template.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !inputs.deprecated }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: '3.10'
@@ -90,7 +90,7 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_matrix) }}
     if: ${{ !inputs.deprecated }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
@@ -42,6 +42,6 @@ jobs:
         uv run isort .
 
     - name: Reviewdog
-      uses: reviewdog/action-suggester@v1
+      uses: reviewdog/action-suggester@6ba408415017b58ee944777db851caa3d2d451b7  # v1
       with:
         tool_name: formatters

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
@@ -48,7 +48,7 @@ jobs:
       run: |
         uv run make -C docs html
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: built-html
         path: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
 
     if: github.repository == 'optuna/optuna-integration'
     steps:
-    - uses: actions/stale@v6
+    - uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578  # v6
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any recent activity.'


### PR DESCRIPTION
## Motivation

Pinning GitHub Actions by commit SHA ensures that workflows use the exact intended action revisions. This improves reproducibility and reduces supply chain risk from mutable tags.

## Description of the changes

- Replaced tag-based GitHub Actions references in workflow files with commit SHA references.