### PR TITLE
Remove duplicate normalized extra names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,19 +99,10 @@ mxnet = [
 pytorch_distributed = [
     "gpytorch",
 ]
-pytorch-distributed = [
-    "gpytorch",
-]
 pytorch_ignite = [
     "pytorch-ignite",
 ]
-pytorch-ignite = [
-    "pytorch-ignite",
-]
 pytorch_lightning = [
-    "lightning",
-]
-pytorch-lightning = [
     "lightning",
 ]
 shap = [


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

uv 0.11.22 started rejecting extras that have the same normalized name. As a result, CI fails while parsing `pyproject.toml` because extras such as `pytorch_distributed` and `pytorch-distributed` normalize to the same name.
https://github.com/astral-sh/uv/releases/tag/0.11.22

## Description of the changes

Removed duplicate hyphenated extra aliases for PyTorch integrations from `pyproject.toml`.

The underscore-style extras are kept because they are used by the existing CI workflow integration names.
https://github.com/optuna/optuna-integration/blob/e0a005c9ed253924b74d14f7e65d6597e810725a/.github/workflows/checks_template.yml#L101