### PR TITLE
Fix for lightgbm CI

### DIFF
--- a/optuna_integration/lightgbm/lightgbm.py
+++ b/optuna_integration/lightgbm/lightgbm.py
@@ -7,9 +7,10 @@ from optuna._imports import try_import
 
 
 if TYPE_CHECKING:
-    from lightgbm.basic import _LGBM_BoosterEvalMethodResultType
-    from lightgbm.basic import _LGBM_BoosterEvalMethodResultWithStandardDeviationType
     from lightgbm.callback import CallbackEnv
+
+    # LightGBM's evaluation result type differs between versions.
+    _LGBMEvaluationResult = tuple[str, str, float, bool]
 
 
 with try_import() as _imports:
@@ -66,11 +67,7 @@ class LightGBMPruningCallback:
 
     def _find_evaluation_result(
         self, target_valid_name: str, env: CallbackEnv
-    ) -> (
-        _LGBM_BoosterEvalMethodResultType
-        | _LGBM_BoosterEvalMethodResultWithStandardDeviationType
-        | None
-    ):
+    ) -> _LGBMEvaluationResult | None:
         evaluation_result_list = env.evaluation_result_list
         if evaluation_result_list is None:
             return None
@@ -86,7 +83,7 @@ class LightGBMPruningCallback:
                 metric != "valid " + self._metric and metric != self._metric
             ):
                 continue
-            return evaluation_result
+            return valid_name, metric, current_score, is_higher_better
 
         return None
 

--- a/tests/lightgbm/test_lightgbm.py
+++ b/tests/lightgbm/test_lightgbm.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import Any
+from typing import cast
 from unittest.mock import patch
 
 import numpy as np
@@ -31,10 +33,12 @@ def test_lightgbm_pruning_callback_call(cv: bool) -> None:
         iteration=1,
     )
 
-    if cv:
-        env = callback_env(evaluation_result_list=[("valid", "binary_error", 1.0, False, 1.0)])
-    else:
-        env = callback_env(evaluation_result_list=[("validation", "binary_error", 1.0, False)])
+    evaluation_result = (
+        ("valid", "binary_error", 1.0, False, 1.0)
+        if cv
+        else ("validation", "binary_error", 1.0, False)
+    )
+    env = callback_env(evaluation_result_list=cast(Any, [evaluation_result]))
 
     # The pruner is deactivated.
     study = optuna.create_study(pruner=DeterministicPruner(False))


### PR DESCRIPTION
## Motivation & Description of the changes

LightGBM 4.7 changed the evaluation result type from tuples to `EvalResult` named tuples, causing type-checking failures due to the use of private LightGBM types.

This PR defines the required return type within `optuna-integration`, absorbing the differences between LightGBM 4.6 and 4.7 without relying on private APIs.