### PR TITLE
BoTorch Sampler unit test using optuna pytest samplers

### DIFF
--- a/tests/botorch/test_botorch.py
+++ b/tests/botorch/test_botorch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Any
 from unittest.mock import patch
@@ -7,9 +8,14 @@ import warnings
 
 import optuna
 from optuna._imports import try_import
+from optuna.samplers import BaseSampler
 from optuna.samplers import RandomSampler
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.storages import RDBStorage
+from optuna.distributions import BaseDistribution
+from optuna.testing.pytest_samplers import BasicSamplerTestCase
+from optuna.testing.pytest_samplers import MultiObjectiveSamplerTestCase
+from optuna.testing.pytest_samplers import RelativeSamplerTestCase
 from optuna.trial import FrozenTrial
 from optuna.trial import Trial
 from optuna.trial import TrialState
@@ -747,3 +753,41 @@ def test_get_constraint_funcs_returns_distinct_columns(n_constraints: int) -> No
             f"Constraint function at index {i} returned {actual}, expected "
             f"{expected}. Late-binding closure regression: see issue #267."
         )
+
+
+class TestBoTorchSampler(
+    BasicSamplerTestCase,
+    RelativeSamplerTestCase,
+    MultiObjectiveSamplerTestCase,
+):
+    @pytest.fixture
+    def sampler(self) -> Callable[[], BaseSampler]:
+        def factory() -> BaseSampler:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+                return BoTorchSampler(n_startup_trials=0)
+
+        return factory
+
+    @pytest.mark.skip(
+        "BoTorchSampler can return a value slightly below the lower bound for log-float "
+        "distributions."
+    )
+    def test_sample_relative_numerical(
+        self,
+        sampler: Callable[[], BaseSampler],
+        x_distribution: BaseDistribution,
+        y_distribution: BaseDistribution,
+    ) -> None:
+        pass
+
+    @pytest.mark.skip(
+        "BoTorchSampler can return a value slightly below the lower bound for log-float "
+        "distributions."
+    )
+    def test_sample_relative_mixed(
+        self,
+        sampler: Callable[[], BaseSampler],
+        x_distribution: BaseDistribution,
+    ) -> None:
+        pass

--- a/tests/botorch/test_botorch.py
+++ b/tests/botorch/test_botorch.py
@@ -8,11 +8,11 @@ import warnings
 
 import optuna
 from optuna._imports import try_import
+from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers import RandomSampler
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.storages import RDBStorage
-from optuna.distributions import BaseDistribution
 from optuna.testing.pytest_samplers import BasicSamplerTestCase
 from optuna.testing.pytest_samplers import MultiObjectiveSamplerTestCase
 from optuna.testing.pytest_samplers import RelativeSamplerTestCase


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
Add class ```TestBoTorchSampler```, which uses optuna ```pytest_sampler```. 


## Description of the changes
<!-- Describe the changes in this PR. -->
Used optuna ```pytest_sampler``` to add ```TestBoTorchSampler```. 
```test_sample_relative_numerical``` and ```test_sample_relative_mixed``` results in error, so we override currently. 