### PR TITLE
Fix flake8 errors in comet and botorch modules

### DIFF
--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -29,8 +29,8 @@ with try_import() as _imports:
     from botorch.acquisition.monte_carlo import qExpectedImprovement
     from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
     from botorch.acquisition.multi_objective import monte_carlo
-    from botorch.acquisition.multi_objective.analytic import ExpectedHypervolumeImprovement
     from botorch.acquisition.multi_objective import objective as multi_objective_objective
+    from botorch.acquisition.multi_objective.analytic import ExpectedHypervolumeImprovement
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
     from botorch.acquisition.objective import GenericMCObjective

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -30,7 +30,9 @@ with try_import() as _imports:
     from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
     from botorch.acquisition.multi_objective import monte_carlo
     from botorch.acquisition.multi_objective.analytic import ExpectedHypervolumeImprovement
-    from botorch.acquisition.multi_objective.objective import FeasibilityWeightedMCMultiOutputObjective
+    from botorch.acquisition.multi_objective.objective import (  # noqa: H301
+        FeasibilityWeightedMCMultiOutputObjective,
+    )
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
     from botorch.acquisition.objective import GenericMCObjective
@@ -80,9 +82,10 @@ with try_import() as _imports_qloghvi:
     from botorch.acquisition.multi_objective.logei import qLogNoisyExpectedHypervolumeImprovement
 
 with try_import() as _imports_qhvkg:
-    from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (
-        qHypervolumeKnowledgeGradient
+    from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (  # noqa: H301
+        qHypervolumeKnowledgeGradient,
     )
+
 
 def _validate_botorch_version_for_constrained_opt(func_name: str) -> None:
     if version.parse(botorch.version.version) < version.parse("0.9.0"):

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -30,9 +30,7 @@ with try_import() as _imports:
     from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
     from botorch.acquisition.multi_objective import monte_carlo
     from botorch.acquisition.multi_objective.analytic import ExpectedHypervolumeImprovement
-    from botorch.acquisition.multi_objective.objective import (  # noqa: H301
-        FeasibilityWeightedMCMultiOutputObjective,
-    )
+    from botorch.acquisition.multi_objective import objective as multi_objective_objective
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
     from botorch.acquisition.objective import GenericMCObjective
@@ -82,9 +80,7 @@ with try_import() as _imports_qloghvi:
     from botorch.acquisition.multi_objective.logei import qLogNoisyExpectedHypervolumeImprovement
 
 with try_import() as _imports_qhvkg:
-    from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (  # noqa: H301
-        qHypervolumeKnowledgeGradient,
-    )
+    from botorch.acquisition.multi_objective import hypervolume_knowledge_gradient
 
 
 def _validate_botorch_version_for_constrained_opt(func_name: str) -> None:
@@ -990,7 +986,7 @@ def qhvkg_candidates_func(
     fit_gpytorch_mll(mll)
 
     n_constraints = train_con.size(1) if train_con is not None else 0
-    objective = FeasibilityWeightedMCMultiOutputObjective(
+    objective = multi_objective_objective.FeasibilityWeightedMCMultiOutputObjective(
         model,
         X_baseline=train_x,
         constraint_idcs=[-n_constraints + i for i in range(n_constraints)],
@@ -998,7 +994,7 @@ def qhvkg_candidates_func(
 
     ref_point = train_obj.min(dim=0).values - 1e-8
 
-    acqf = qHypervolumeKnowledgeGradient(
+    acqf = hypervolume_knowledge_gradient.qHypervolumeKnowledgeGradient(
         model=model,
         ref_point=ref_point,
         num_fantasies=16,

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -30,9 +30,7 @@ with try_import() as _imports:
     from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
     from botorch.acquisition.multi_objective import monte_carlo
     from botorch.acquisition.multi_objective.analytic import ExpectedHypervolumeImprovement
-    from botorch.acquisition.multi_objective.objective import (
-        FeasibilityWeightedMCMultiOutputObjective,
-    )
+    from botorch.acquisition.multi_objective.objective import FeasibilityWeightedMCMultiOutputObjective
     from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
     from botorch.acquisition.objective import ConstrainedMCObjective
     from botorch.acquisition.objective import GenericMCObjective
@@ -83,9 +81,8 @@ with try_import() as _imports_qloghvi:
 
 with try_import() as _imports_qhvkg:
     from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (
-        qHypervolumeKnowledgeGradient,
+        qHypervolumeKnowledgeGradient
     )
-
 
 def _validate_botorch_version_for_constrained_opt(func_name: str) -> None:
     if version.parse(botorch.version.version) < version.parse("0.9.0"):

--- a/optuna_integration/botorch/botorch.py
+++ b/optuna_integration/botorch/botorch.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -21,7 +19,6 @@ from optuna.samplers._base import _process_constraints_after_trial
 from optuna.search_space import IntersectionSearchSpace
 from optuna.study import Study
 from optuna.study import StudyDirection
-from optuna.study._constrained_optimization import _CONSTRAINTS_KEY
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
 from packaging import version

--- a/optuna_integration/comet/comet.py
+++ b/optuna_integration/comet/comet.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from __future__ import annotations
 
 from collections.abc import Callable


### PR DESCRIPTION
Fixes optuna/optuna-integration#202

## Summary
- Remove legacy `# flake8: noqa` suppressions from `comet.py` and `botorch.py`
- Remove unused `_CONSTRAINTS_KEY` import in `botorch.py` (F401)
- Verified with `flake8 optuna_integration/comet optuna_integration/botorch`

## Test plan
- [x] `flake8 optuna_integration/comet optuna_integration/botorch` passes locally