### PR TITLE
Fix the scheduled CI failures in the MyPy checks.

### DIFF
--- a/optuna_integration/pytorch_distributed/pytorch_distributed.py
+++ b/optuna_integration/pytorch_distributed/pytorch_distributed.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from datetime import datetime
 import functools
 from typing import Any
+from typing import cast
 from typing import overload
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -125,7 +126,7 @@ class TorchDistributedTrial(optuna.trial.BaseTrial):
                     raise RuntimeError("torch distributed is not initialized.")
                 default_pg: "ProcessGroup" = dist.group.WORLD
                 if dist.get_backend(default_pg) == "nccl":
-                    new_group: "ProcessGroup" = dist.new_group(backend="gloo")
+                    new_group = cast("ProcessGroup", dist.new_group(backend="gloo"))
                     _g_pg = new_group
                 else:
                     _g_pg = default_pg


### PR DESCRIPTION
<!-- Thank you for creating a pull request! In general, we merge your pull request after it gets two or more approvals. To proceed to the review process by the maintainers, please make sure that the PR meets the following conditions: (1) it passes all CI checks, and (2) it is neither in the draft nor WIP state. If you wish to discuss the PR in the draft state or need any other help, please mention the Optuna development team in the PR. -->

## Motivation

Fix the scheduled CI failures in the MyPy checks.
https://github.com/optuna/optuna-integration/actions/runs/34175419884/job/101903744320

## Description of the changes

Cast the return value of `torch.distributed.new_group()` to `ProcessGroup`, since all ranks participate in the created group.
