### PR TITLE
Slice pruning fit parameters by training fold

### DIFF
--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -355,11 +355,19 @@ class _Objective:
     ) -> list[Number]:
         X_train, y_train = _safe_split(estimator, self.X, self.y, train)
         X_test, y_test = _safe_split(estimator, self.X, self.y, test, train_indices=train)
+        fit_params = _check_fit_params(
+            self.X,
+            {key: value for key, value in partial_fit_params.items() if key != "classes"},
+            train,
+        )
+        # Classes describe the full target space, not individual samples.
+        if "classes" in partial_fit_params:
+            fit_params["classes"] = partial_fit_params["classes"]
 
         start_time = time()
 
         try:
-            estimator.partial_fit(X_train, y_train, **partial_fit_params)
+            estimator.partial_fit(X_train, y_train, **fit_params)
 
         except Exception as e:
             if self.error_score == "raise":

--- a/tests/sklearn/test_sklearn.py
+++ b/tests/sklearn/test_sklearn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 import warnings
@@ -26,6 +27,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import SGDClassifier
 from sklearn.metrics import make_scorer
 from sklearn.metrics import r2_score
+from sklearn.model_selection import KFold
 from sklearn.model_selection import PredefinedSplit
 from sklearn.neighbors import KernelDensity
 from sklearn.tree import DecisionTreeRegressor
@@ -87,6 +89,45 @@ def test_optuna_search(enable_pruning: bool, fit_params: str) -> None:
     optuna_search.decision_function(X)
     optuna_search.predict(X)
     optuna_search.score(X, y)
+
+
+@pytest.mark.parametrize("n_classes", [2, 12])
+@pytest.mark.parametrize("subsample", [1.0, 0.75])
+def test_optuna_search_pruning_sample_weight(n_classes: int, subsample: float) -> None:
+    class SampleWeightClassifier(SGDClassifier):
+        def partial_fit(
+            self,
+            X: np.ndarray,
+            y: np.ndarray,
+            classes: np.ndarray | None = None,
+            sample_weight: Any = None,
+        ) -> SampleWeightClassifier:
+            super().partial_fit(X, y, classes=classes, sample_weight=sample_weight)
+            np.testing.assert_array_equal(sample_weight, X[:, 0] + 1)
+            np.testing.assert_array_equal(classes, np.unique(y_all[search.sample_indices_]))
+            return self
+
+    X = np.arange(12).reshape(-1, 1)
+    y_all = np.arange(12) % n_classes
+    sample_weight = list(range(1, 13))
+    with pytest.warns(ExperimentalWarning):
+        search = OptunaSearchCV(
+            SampleWeightClassifier(random_state=0),
+            {},
+            cv=KFold(3),
+            enable_pruning=True,
+            error_score="raise",
+            max_iter=2,
+            n_trials=1,
+            random_state=0,
+            refit=False,
+            subsample=subsample,
+        )
+
+    search.fit(X, y_all, sample_weight=sample_weight)
+
+    assert np.isfinite(search.best_score_)
+    assert sample_weight == list(range(1, 13))
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")


### PR DESCRIPTION
## Motivation

With pruning enabled, `OptunaSearchCV` slices `X` and `y` for each training fold but forwards full-dataset fit parameters to `partial_fit`. Passing `sample_weight` therefore fails with a shape mismatch.

## Description of the changes

Slice sample-wise parameters with the existing `_check_fit_params` helper before calling `partial_fit`. Preserve `classes` as global target metadata even when its length matches the number of samples.

The regression uses real `SGDClassifier.partial_fit`, checks weight-to-row alignment, covers subsampling and the classes-length edge case, and verifies the caller's weight list is unchanged. All four cases fail on the unchanged base. The sklearn integration suite passes with the fix: **33 passed**. Black, isort, flake8 and mypy pass for both changed files. Other integration suites were not run.

AI assistance was used for implementation and local verification.

Fixes #315.
