### PR TITLE
Keep pruning cross-validation folds stable across epochs

### DIFF
--- a/optuna_integration/sklearn/sklearn.py
+++ b/optuna_integration/sklearn/sklearn.py
@@ -311,8 +311,10 @@ class _Objective:
         if self.return_train_score:
             scores["train_score"] = np.empty(n_splits)
 
+        # Each estimator must keep the same training and validation samples across epochs.
+        splits = list(self.cv.split(self.X, self.y, groups=self.groups))
         for step in range(self.max_iter):
-            for i, (train, test) in enumerate(self.cv.split(self.X, self.y, groups=self.groups)):
+            for i, (train, test) in enumerate(splits):
                 out = list(
                     np.asarray(
                         self._partial_fit_and_score(

--- a/tests/sklearn/test_sklearn.py
+++ b/tests/sklearn/test_sklearn.py
@@ -26,9 +26,46 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import SGDClassifier
 from sklearn.metrics import make_scorer
 from sklearn.metrics import r2_score
+from sklearn.model_selection import KFold
 from sklearn.model_selection import PredefinedSplit
 from sklearn.neighbors import KernelDensity
 from sklearn.tree import DecisionTreeRegressor
+
+
+def test_pruning_keeps_validation_samples_out_of_training() -> None:
+    class TrackingClassifier(SGDClassifier):
+        def partial_fit(
+            self, X: np.ndarray, y: np.ndarray, classes: np.ndarray | None = None
+        ) -> TrackingClassifier:
+            super().partial_fit(X, y, classes=classes)
+            self.seen_samples_ = getattr(self, "seen_samples_", set()) | set(X[:, 0])
+            return self
+
+    def score(estimator: TrackingClassifier, X: np.ndarray, y: np.ndarray) -> float:
+        assert estimator.seen_samples_.isdisjoint(X[:, 0])
+        return float(estimator.score(X, y))
+
+    X = np.arange(30).reshape(-1, 1)
+    y = np.arange(30) % 2
+    cv = KFold(3, shuffle=True, random_state=np.random.RandomState(0))
+    with pytest.warns(ExperimentalWarning):
+        search = OptunaSearchCV(
+            TrackingClassifier(random_state=0),
+            {},
+            cv=cv,
+            enable_pruning=True,
+            error_score="raise",
+            max_iter=3,
+            n_trials=2,
+            random_state=0,
+            refit=False,
+            scoring=score,
+        )
+
+    search.fit(X, y)
+
+    assert np.isfinite(search.best_score_)
+    assert len(search.trials_) == 2
 
 
 def test_is_arraylike() -> None:


### PR DESCRIPTION
## Motivation

Pruning keeps a fitted estimator for each CV fold across epochs, but recreates the folds on every epoch. A shuffled splitter with a mutable `RandomState` then puts previously trained samples into the validation fold, contaminating its score.

## Description of the changes

Materialize the splits once per trial and reuse them for its epochs. This preserves per-trial splitter behavior while keeping each estimator's held-out samples fixed.

The regression trains actual `SGDClassifier` instances and asserts that validation samples never appear in their accumulated training samples, across three epochs and two trials. It fails on the unchanged base. Local sklearn integration suite: **30 passed**. Changed-file Black, isort, flake8 and mypy checks passed. Other integration suites were not run.

AI assistance was used for implementation and local verification.

Fixes #317.
